### PR TITLE
fix: only augment `vue`, not sub-packages

### DIFF
--- a/src/runtime/plugins/01.plugin.ts
+++ b/src/runtime/plugins/01.plugin.ts
@@ -256,24 +256,6 @@ declare module 'nuxt/dist/app/nuxt' {
   interface NuxtApp extends PluginsInjections {}
 }
 
-declare module '@vue/runtime-core' {
-  interface ComponentCustomProperties {
-    $getLocale: () => string
-    $getLocales: () => string[]
-    $t: <T extends Record<string, string | number | boolean>>(
-      key: string,
-      params?: T,
-      defaultValue?: string
-    ) => string | number | boolean | Translations | PluralTranslations | unknown[] | unknown | null
-    $tc: (key: string, count: number, defaultValue?: string) => string
-    $has: (key: string) => boolean
-    $mergeTranslations: (newTranslations: Translations) => void
-    $switchLocale: (locale: string) => void
-    $localeRoute: (to: RouteLocationRaw, locale?: string) => RouteLocationRaw
-    $loadPageTranslations: (locale: string, routeName: string) => Promise<void>
-  }
-}
-
 declare module 'vue' {
   // eslint-disable-next-line @typescript-eslint/no-empty-object-type
   interface ComponentCustomProperties extends PluginsInjections {}


### PR DESCRIPTION
Based on your description of type issues in https://github.com/nuxt-modules/i18n/issues/2629#issuecomment-2296775308 I took a quick look.

There's a weird type augmentation behavior when modules mix augmenting `vue` and `@vue/runtime-core` resulting in broken types (see https://github.com/nuxt/nuxt/pull/28542). This may not be the fix for the plugin type definitions, I wasn't able to run npm scripts to test it myself, probably due to some local package manager issues.

