### PR TITLE
[Enhancement][Breaking changes] Add support for displayName of the type Locale

### DIFF
--- a/docs/api/methods.md
+++ b/docs/api/methods.md
@@ -4,30 +4,65 @@ outline: deep
 
 # 🛠️ Methods
 
-## 🌍 `$getLocale`
+## 🌍 `$getLocaleCode`
 
-Returns the current locale code.
+Returns the current locale object.
 
 **Type**: `() => string`
 
 **Example**:
 
 ```typescript
-const locale = $getLocale()
-// Output: 'en' (assuming the current locale is English)
+const locale = $getLocaleCode();
+```
+
+**Output**
+
+```typescript
+// Assuming the current locale is English
+"en";
+```
+
+## 🌍 `$getLocale`
+
+Returns the current locale object.
+
+**Type**: `() => Locale`
+
+**Example**:
+
+```typescript
+const locale = $getLocale();
+```
+
+**Output**
+
+```typescript
+// Assuming the current locale is English
+{ code: 'en', iso: 'en-US', dir: 'ltr', displayName: 'English' }
 ```
 
 ## 🌍 `$getLocales`
 
 Returns an array of all available locales configured in the module.
 
-**Type**: `() => Array<{ code: string; iso?: string; dir?: string }>`
+Values are predefined inside the `nuxt.config.ts`
+
+**Type**: `() => Array<{ code: string; iso?: string; dir?: string, disabled?: boolean, displayName: string }>`
 
 **Example**:
 
 ```typescript
-const locales = $getLocales()
-// Output: [{ code: 'en', iso: 'en-US', dir: 'ltr' }, { code: 'fr', iso: 'fr-FR', dir: 'ltr' }]
+const locales = $getLocales();
+```
+
+**Output**
+
+```typescript
+[
+  { code: "en", iso: "en-US", dir: "ltr", displayName: "English" },
+  { code: "fr", iso: "fr-FR", dir: "ltr" },
+];
 ```
 
 ## 🔍 `$getRouteName`
@@ -37,14 +72,21 @@ Retrieves the base route name without any locale-specific prefixes or suffixes.
 **Type**: `(route?: RouteLocationNormalizedLoaded | RouteLocationResolvedGeneric, locale?: string) => string`
 
 **Parameters**:
+
 - **route**: `RouteLocationNormalizedLoaded | RouteLocationResolvedGeneric | undefined` — Optional. The route object from which to extract the name.
 - **locale**: `string | undefined` — Optional. The locale code to consider when extracting the route name.
 
 **Example**:
 
 ```typescript
-const routeName = $getRouteName(routeObject, 'fr')
-// Output: 'index' (assuming the base route name is 'index')
+const routeName = $getRouteName(routeObject, "fr");
+```
+
+**Output**:
+
+```typescript
+// assuming the base route name is 'index'
+"index";
 ```
 
 ## 🔍 `$t`
@@ -54,6 +96,7 @@ Fetches a translation for the given key. Optionally interpolates parameters.
 **Type**: `(key: string, params?: Record<string, any>, defaultValue?: string) => string`
 
 **Parameters**:
+
 - **key**: `string` — The translation key.
 - **params**: `Record<string, any> | undefined` — Optional. A record of key-value pairs to interpolate into the translation.
 - **defaultValue**: `string | undefined` — Optional. The default value to return if the translation is not found.
@@ -61,8 +104,13 @@ Fetches a translation for the given key. Optionally interpolates parameters.
 **Example**:
 
 ```typescript
-const welcomeMessage = $t('welcome', { username: 'Alice', unreadCount: 5 })
-// Output: "Welcome, Alice! You have 5 unread messages."
+const welcomeMessage = $t("welcome", { username: "Alice", unreadCount: 5 });
+```
+
+**Output**:
+
+```typescript
+"Welcome, Alice! You have 5 unread messages.";
 ```
 
 ## 🔢 `$tc`
@@ -72,6 +120,7 @@ Fetches a pluralized translation for the given key based on the count.
 **Type**: `(key: string, count: number, defaultValue?: string) => string`
 
 **Parameters**:
+
 - **key**: `string` — The translation key.
 - **count**: `number` — The count for pluralization.
 - **defaultValue**: `string | undefined` — Optional. The default value to return if the translation is not found.
@@ -79,8 +128,14 @@ Fetches a pluralized translation for the given key based on the count.
 **Example**:
 
 ```typescript
-const appleCountMessage = $tc('apples', 10)
-// Output: "10 apples" (assuming the plural rule for 'apples' is defined correctly)
+const appleCountMessage = $tc("apples", 10);
+```
+
+**Output**:
+
+```typescript
+// assuming the plural rule for 'apples' is defined correctly
+"10 apples";
 ```
 
 ## 🔢 `$tn`
@@ -90,17 +145,25 @@ Formats a number according to the current locale using `Intl.NumberFormat`.
 **Type**: `(value: number, options?: Intl.NumberFormatOptions) => string`
 
 **Parameters**:
+
 - **value**: `number` — The number to format.
 - **options**: `Intl.NumberFormatOptions | undefined` — Optional. `Intl.NumberFormatOptions` to customize the formatting.
 
 **Example**:
 
 ```typescript
-const formattedNumber = $tn(1234567.89, { style: 'currency', currency: 'USD' })
-// Output: "$1,234,567.89" in the 'en-US' locale
+const formattedNumber = $tn(1234567.89, { style: "currency", currency: "USD" });
+```
+
+**Output**:
+
+```typescript
+// Assuming the locale is English
+"$1,234,567.89";
 ```
 
 ### Use Cases:
+
 - Formatting numbers as currency, percentages, or decimals in the appropriate locale format.
 - Customizing the number format using `Intl.NumberFormatOptions` such as currency, minimum fraction digits, etc.
 
@@ -111,17 +174,30 @@ Formats a date according to the current locale using `Intl.DateTimeFormat`.
 **Type**: `(value: Date | number | string, options?: Intl.DateTimeFormatOptions) => string`
 
 **Parameters**:
+
 - **value**: `Date | number | string` — The date to format, which can be a `Date` object, a timestamp, or a date string.
 - **options**: `Intl.DateTimeFormatOptions | undefined` — Optional. `Intl.DateTimeFormatOptions` to customize the formatting.
 
 **Example**:
 
 ```typescript
-const formattedDate = $td(new Date(), { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' })
-// Output: "Friday, September 1, 2023" in the 'en-US' locale
+const formattedDate = $td(new Date(), {
+  weekday: "long",
+  year: "numeric",
+  month: "long",
+  day: "numeric",
+});
+```
+
+**Example**:
+
+```typescript
+// Assuming the locale is English
+"Friday, September 1, 2023";
 ```
 
 ### Use Cases:
+
 - Displaying dates in a format that aligns with the user's locale, including long or short date formats.
 - Customizing date output using options like weekday names, time formats, and timezone settings.
 
@@ -132,14 +208,21 @@ Return current route with the given locale
 **Type**: `(locale: string) => RouteLocationRaw`
 
 **Parameters**:
+
 - **locale**: `string` — Target locale.
 
 **Example**:
 
 ```typescript
-// on /en/news
-const routeFr = $switchLocaleRoute('fr')
-// Output: A route object with the new locale applied, e.g., { name: 'localized-news', params: { locale: 'fr' } }
+// Currnet route: /en/news
+const routeFr = $switchLocaleRoute("fr");
+```
+
+**Output**:
+
+```typescript
+// A route object with the new locale applied, e.g.,
+{ name: 'localized-news', params: { locale: 'fr' } }
 ```
 
 ## 🔄 `$switchLocalePath`
@@ -149,15 +232,22 @@ Return url of current route with the given locale
 **Type**: `(locale: string) => string`
 
 **Parameters**:
+
 - **locale**: `string` — Target locale.
 
 **Example**:
 
 ```typescript
-// on /en/news
-const routeFr = $switchLocaleRoute('fr')
-window.location.href = routeFr
-// Output: url with new locale applied, e.g., '/fr/nouvelles'
+// Currnet route: /en/news
+const routeFr = $switchLocaleRoute("fr");
+window.location.href = routeFr;
+```
+
+**Output**:
+
+```typescript
+// url with new locale applied, e.g.,
+"/fr/nouvelles";
 ```
 
 ## 🔄 `$switchLocale`
@@ -167,22 +257,28 @@ Switches to the given locale and redirects the user to the appropriate localized
 **Type**: `(locale: string) => void`
 
 **Parameters**:
+
 - **locale**: `string` — The locale to switch to.
+
+**Action**: Redirects the user to the French version of the route
+
+**Attention**: Be aware that this will trigger a page navigation
 
 **Example**:
 
 ```typescript
-$switchLocale('fr')
-// Output: Redirects the user to the French version of the route
+$switchLocale("fr");
 ```
+
 ## 🔄 `$setI18nRouteParams`
 
-set localized versions of params for all switchLocale* methods and returns passed value
+set localized versions of params for all switchLocale\* methods and returns passed value
 MUST be called inside useAsyncData
 
 **Type**: `(value: Record<LocaleCode, Record<string, string>> | null) => Record<LocaleCode, Record<string, string>> | null`
 
 **Parameters**:
+
 - **value**: `Record<LocaleCode, Record<string, string>> | null` — params of current route for other locale
 
 **Example**:
@@ -233,14 +329,21 @@ Generates a localized route object based on the target route.
 **Type**: `(to: RouteLocationRaw, locale?: string) => RouteLocationResolved`
 
 **Parameters**:
+
 - **to**: `RouteLocationRaw` — The target route object.
 - **locale**: `string | undefined` — Optional. The locale for the generated route.
 
 **Example**:
 
 ```typescript
-const localizedRoute = $localeRoute({ name: 'index' })
-// Output: A route object with the current locale applied, e.g., { name: 'index', params: { locale: 'fr' } }
+const localizedRoute = $localeRoute({ name: "index" });
+```
+
+**Output**:
+
+```typescript
+//  A route object with the current locale applied, e.g.,
+{ name: 'index', params: { locale: 'fr' } }
 ```
 
 ## 🔄 `$localePath`
@@ -250,14 +353,21 @@ Return url based on the target route
 **Type**: `(to: RouteLocationRaw, locale?: string) => string`
 
 **Parameters**:
+
 - **to**: `RouteLocationRaw` — The target route object.
 - **locale**: `string | undefined` — Optional. The locale for the generated route.
 
 **Example**:
 
 ```typescript
-const localizedRoute = $localeRoute({ name: 'news' })
-// Output: url with new locale applied, e.g., '/en/nouvelles'
+const localizedRoute = $localeRoute({ name: "news" });
+```
+
+**Output**:
+
+```typescript
+// Url with new locale applied, e.g.,
+"/en/nouvelles";
 ```
 
 ## 🗂️ `$mergeTranslations`
@@ -267,15 +377,17 @@ Merges new translations into the existing translation cache for the current rout
 **Type**: `(newTranslations: Record<string, string>) => void`
 
 **Parameters**:
+
 - **newTranslations**: `Record<string, string>` — The new translations to merge.
+
+**Action**: Updates the translation cache with the new French translation
 
 **Example**:
 
 ```typescript
 $mergeTranslations({
-  welcome: 'Bienvenue, {username}!'
-})
-// Output: Updates the translation cache with the new French translation
+  welcome: "Bienvenue, {username}!",
+});
 ```
 
 ## 🚦 `$defineI18nRoute`
@@ -285,6 +397,7 @@ Defines route behavior based on the current locale. This method can be used to c
 **Type**: `(routeDefinition: { locales?: string[] | Record<string, Record<string, TranslationObject>>, localeRoutes?: Record<string, string> }) => void`
 
 **Parameters**:
+
 - **locales**: `string[] | Record<string, Record<string, TranslationObject>>` — This property determines which locales are available for the route.
 - **localeRoutes**: `Record<string, string> | undefined` — Optional. Custom routes for specific locales.
 
@@ -293,15 +406,14 @@ Defines route behavior based on the current locale. This method can be used to c
 ```typescript
 $defineI18nRoute({
   locales: {
-    en: { greeting: 'Hello', farewell: 'Goodbye' },
-    ru: { greeting: 'Привет', farewell: 'До свидания' },
+    en: { greeting: "Hello", farewell: "Goodbye" },
+    ru: { greeting: "Привет", farewell: "До свидания" },
   },
   localeRoutes: {
-    ru: '/localesubpage',
+    ru: "/localesubpage",
   },
-})
+});
 ```
-
 
 ### Use Cases:
 
@@ -316,30 +428,30 @@ This function offers a flexible way to manage routing and localization in your N
 ### Example 1: Controlling Access Based on Locales
 
 ```typescript
-import { useNuxtApp } from '#imports'
+import { useNuxtApp } from "#imports";
 
-const { $defineI18nRoute } = useNuxtApp()
+const { $defineI18nRoute } = useNuxtApp();
 
 $defineI18nRoute({
-  locales: ['en', 'fr', 'de'] // Only these locales are allowed for this route
-})
+  locales: ["en", "fr", "de"], // Only these locales are allowed for this route
+});
 ```
 
 ### Example 2: Providing Translations for Locales
 
 ```typescript
-import { useNuxtApp } from '#imports'
+import { useNuxtApp } from "#imports";
 
-const { $defineI18nRoute } = useNuxtApp()
+const { $defineI18nRoute } = useNuxtApp();
 
 $defineI18nRoute({
   locales: {
-    en: { greeting: 'Hello', farewell: 'Goodbye' },
-    fr: { greeting: 'Bonjour', farewell: 'Au revoir' },
-    de: { greeting: 'Hallo', farewell: { aaa: { bbb: "Auf Wiedersehen" } } },
-    ru: {} // Russian locale is allowed but no translations are provided
-  }
-})
+    en: { greeting: "Hello", farewell: "Goodbye" },
+    fr: { greeting: "Bonjour", farewell: "Au revoir" },
+    de: { greeting: "Hallo", farewell: { aaa: { bbb: "Auf Wiedersehen" } } },
+    ru: {}, // Russian locale is allowed but no translations are provided
+  },
+});
 ```
 
 ### 📝 Explanation:
@@ -354,14 +466,14 @@ Here's an example of how to use these methods in a Nuxt component:
 ```vue
 <template>
   <div>
-    <p>{{ $t('key2.key2.key2.key2.key2') }}</p>
+    <p>{{ $t("key2.key2.key2.key2.key2") }}</p>
     <p>Current Locale: {{ $getLocale() }}</p>
 
     <div>
-      {{ $t('welcome', { username: 'Alice', unreadCount: 5 }) }}
+      {{ $t("welcome", { username: "Alice", unreadCount: 5 }) }}
     </div>
     <div>
-      {{ $tc('apples', 10) }}
+      {{ $tc("apples", 10) }}
     </div>
 
     <div>
@@ -376,17 +488,16 @@ Here's an example of how to use these methods in a Nuxt component:
     </div>
 
     <div>
-      <NuxtLink :to="$localeRoute({ name: 'index' })">
-        Go to Index
-      </NuxtLink>
+      <NuxtLink :to="$localeRoute({ name: 'index' })"> Go to Index </NuxtLink>
     </div>
   </div>
 </template>
 
 <script setup>
-import { useI18n } from '#imports'
+import { useI18n } from "#imports";
 
-const { $getLocale, $switchLocale, $getLocales, $localeRoute, $t, $tc } = useI18n()
+const { $getLocale, $switchLocale, $getLocales, $localeRoute, $t, $tc } =
+  useI18n();
 </script>
 ```
 
@@ -395,9 +506,10 @@ const { $getLocale, $switchLocale, $getLocales, $localeRoute, $t, $tc } = useI18
 **Example:**
 
 ```typescript
-import { useNuxtApp } from '#imports'
+import { useNuxtApp } from "#imports";
 
-const { $getLocale, $switchLocale, $getLocales, $localeRoute, $t } = useNuxtApp()
+const { $getLocale, $switchLocale, $getLocales, $localeRoute, $t } =
+  useNuxtApp();
 ```
 
 ## 🧩 `useI18n` Composable
@@ -405,9 +517,9 @@ const { $getLocale, $switchLocale, $getLocales, $localeRoute, $t } = useNuxtApp(
 **Example:**
 
 ```typescript
-import { useI18n } from '#imports'
+import { useI18n } from "#imports";
 
-const { $getLocale, $switchLocale, $getLocales, $localeRoute, $t } = useI18n()
+const { $getLocale, $switchLocale, $getLocales, $localeRoute, $t } = useI18n();
 // or
-const i18n = useI18n()
+const i18n = useI18n();
 ```

--- a/docs/composables/useI18n.md
+++ b/docs/composables/useI18n.md
@@ -12,100 +12,100 @@ The `useI18n` composable returns an object containing several key methods and pr
 
 ### `$getLocale`
 
-- **Type**: `() => string`
-- **Description**: Returns the current locale of the application.
-- **Example**:
-  ```js
-  const { $getLocale } = useI18n()
-  const locale = $getLocale()
-  console.log(locale) // e.g., 'en'
-  ```
+-   **Type**: `() => Locale`
+-   **Description**: Returns the current locale of the application.
+-   **Example**:
+    ```js
+    const { $getLocale } = useI18n()
+    const locale = $getLocale()
+    console.log(locale) // e.g., '{ code: 'en', iso: 'en-US' }'
+    ```
 
 ### `$getLocales`
 
-- **Type**: `() => Locale[]`
-- **Description**: Returns an array of all available locales in the application.
-- **Example**:
-  ```js
-  const { $getLocales } = useI18n()
-  const locales = $getLocales()
-  console.log(locales) // e.g., [{ code: 'en', iso: 'en-US' }, { code: 'fr', iso: 'fr-FR' }]
-  ```
+-   **Type**: `() => Locale[]`
+-   **Description**: Returns an array of all available locales in the application.
+-   **Example**:
+    ```js
+    const { $getLocales } = useI18n()
+    const locales = $getLocales()
+    console.log(locales) // e.g., [{ code: 'en', iso: 'en-US' }, { code: 'fr', iso: 'fr-FR' }]
+    ```
 
 ### `$t`
 
-- **Type**: `<T extends Record<string, string | number | boolean>>(key: string, params?: T, defaultValue?: string) => string | number | boolean | Translations | PluralTranslations | unknown[] | unknown | null`
-- **Description**: Translates a given key to the corresponding localized string, optionally replacing placeholders with provided parameters and falling back to a default value if the key is not found.
-- **Example**:
-  ```js
-  const { $t } = useI18n()
-  const greeting = $t('hello', { name: 'John' }, 'Hello!')
-  console.log(greeting) // e.g., 'Hello, John'
-  ```
+-   **Type**: `<T extends Record<string, string | number | boolean>>(key: string, params?: T, defaultValue?: string) => string | number | boolean | Translations | PluralTranslations | unknown[] | unknown | null`
+-   **Description**: Translates a given key to the corresponding localized string, optionally replacing placeholders with provided parameters and falling back to a default value if the key is not found.
+-   **Example**:
+    ```js
+    const { $t } = useI18n()
+    const greeting = $t('hello', { name: 'John' }, 'Hello!')
+    console.log(greeting) // e.g., 'Hello, John'
+    ```
 
 ### `$tc`
 
-- **Type**: `(key: string, count: number, defaultValue?: string) => string`
-- **Description**: Translates a given key with pluralization based on the provided count, optionally falling back to a default value if the key is not found.
-- **Example**:
-  ```js
-  const { $tc } = useI18n()
-  const message = $tc('apples', 3, '3 apples')
-  console.log(message) // e.g., '3 apples'
-  ```
+-   **Type**: `(key: string, count: number, defaultValue?: string) => string`
+-   **Description**: Translates a given key with pluralization based on the provided count, optionally falling back to a default value if the key is not found.
+-   **Example**:
+    ```js
+    const { $tc } = useI18n()
+    const message = $tc('apples', 3, '3 apples')
+    console.log(message) // e.g., '3 apples'
+    ```
 
 ### `$has`
 
-- **Type**: `(key: string) => boolean`
-- **Description**: Checks if a translation key exists for the current locale.
-- **Example**:
-  ```js
-  const { $has } = useI18n()
-  const exists = $has('hello')
-  console.log(exists) // e.g., true
-  ```
+-   **Type**: `(key: string) => boolean`
+-   **Description**: Checks if a translation key exists for the current locale.
+-   **Example**:
+    ```js
+    const { $has } = useI18n()
+    const exists = $has('hello')
+    console.log(exists) // e.g., true
+    ```
 
 ### `$mergeTranslations`
 
-- **Type**: `(newTranslations: Translations) => void`
-- **Description**: Merges additional translations into the existing ones for the current locale.
-- **Example**:
-  ```js
-  const { $mergeTranslations } = useI18n()
-  $mergeTranslations({
-    hello: 'Hello World',
-  })
-  ```
+-   **Type**: `(newTranslations: Translations) => void`
+-   **Description**: Merges additional translations into the existing ones for the current locale.
+-   **Example**:
+    ```js
+    const { $mergeTranslations } = useI18n()
+    $mergeTranslations({
+        hello: 'Hello World'
+    })
+    ```
 
 ### `$switchLocale`
 
-- **Type**: `(locale: string) => void`
-- **Description**: Switches the application's locale to the specified locale.
-- **Example**:
-  ```js
-  const { $switchLocale } = useI18n()
-  $switchLocale('fr')
-  ```
+-   **Type**: `(locale: string) => void`
+-   **Description**: Switches the application's locale to the specified locale.
+-   **Example**:
+    ```js
+    const { $switchLocale } = useI18n()
+    $switchLocale('fr')
+    ```
 
 ### `$localeRoute`
 
-- **Type**: `(to: RouteLocationRaw, locale?: string) => RouteLocationRaw`
-- **Description**: Generates a localized route based on the specified route and optionally the specified locale.
-- **Example**:
-  ```js
-  const { $localeRoute } = useI18n()
-  const route = $localeRoute('/about', 'fr')
-  ```
+-   **Type**: `(to: RouteLocationRaw, locale?: string) => RouteLocationRaw`
+-   **Description**: Generates a localized route based on the specified route and optionally the specified locale.
+-   **Example**:
+    ```js
+    const { $localeRoute } = useI18n()
+    const route = $localeRoute('/about', 'fr')
+    ```
 
 ### `$loadPageTranslations`
 
-- **Type**: `(locale: string, routeName: string) => Promise<void>`
-- **Description**: Loads translations for the specified page and locale, enabling lazy-loading of translations.
-- **Example**:
-  ```js
-  const { $loadPageTranslations } = useI18n()
-  await $loadPageTranslations('fr', 'home')
-  ```
+-   **Type**: `(locale: string, routeName: string) => Promise<void>`
+-   **Description**: Loads translations for the specified page and locale, enabling lazy-loading of translations.
+-   **Example**:
+    ```js
+    const { $loadPageTranslations } = useI18n()
+    await $loadPageTranslations('fr', 'home')
+    ```
 
 ## 🛠️ Example Usages
 
@@ -114,8 +114,8 @@ The `useI18n` composable returns an object containing several key methods and pr
 Retrieve the current locale of the application.
 
 ```js
-const { $getLocale } = useI18n()
-const locale = $getLocale()
+const { $getLocaleCode } = useI18n()
+const locale = $getLocaleCode()
 ```
 
 ### Translation with Parameters

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -12,17 +12,17 @@ Here's a basic setup to get started with `Nuxt I18n Micro`:
 
 ```typescript
 export default defineNuxtConfig({
-  modules: ['nuxt-i18n-micro'],
-  i18n: {
-    locales: [
-      { code: 'en', iso: 'en-US', dir: 'ltr' },
-      { code: 'fr', iso: 'fr-FR', dir: 'ltr' },
-      { code: 'de', iso: 'de-DE', dir: 'ltr' },
-    ],
-    defaultLocale: 'en',
-    translationDir: 'locales',
-    meta: true,
-  },
+    modules: ['nuxt-i18n-micro'],
+    i18n: {
+        locales: [
+            { code: 'en', iso: 'en-US', dir: 'ltr', displayName: 'English' },
+            { code: 'fr', iso: 'fr-FR', dir: 'ltr', displayName: 'French' },
+            { code: 'de', iso: 'de-DE', dir: 'ltr', displayName: 'German' }
+        ],
+        defaultLocale: 'en',
+        translationDir: 'locales',
+        meta: true
+    }
 })
 ```
 
@@ -34,25 +34,25 @@ This example demonstrates how to switch locales programmatically using buttons:
 
 ```vue
 <template>
-  <div>
-    <p>Current Locale: {{ $getLocale() }}</p>
     <div>
-      <button
-        v-for="locale in $getLocales()"
-        :key="locale.code"
-        :disabled="locale.code === $getLocale()"
-        @click="() => $switchLocale(locale.code)"
-      >
-        Switch to {{ $t(locale.code) }}
-      </button>
+        <p>Current Locale: {{ $getLocaleCode() }}</p>
+        <div>
+            <button
+                v-for="locale in $getLocales()"
+                :key="locale.code"
+                :disabled="locale.code === $getLocaleCode()"
+                @click="() => $switchLocale(locale.code)"
+            >
+                Switch to {{ $t(locale.code) }}
+            </button>
+        </div>
     </div>
-  </div>
 </template>
 
 <script setup>
 import { useNuxtApp } from '#imports'
 
-const { $getLocale, $switchLocale, $getLocales, $t } = useNuxtApp()
+const { $getLocaleCode, $switchLocale, $getLocales, $t } = useNuxtApp()
 </script>
 ```
 
@@ -60,9 +60,9 @@ const { $getLocale, $switchLocale, $getLocales, $t } = useNuxtApp()
 
 ```json
 {
-  "en": "English",
-  "fr": "Français",
-  "de": "Deutsch"
+    "en": "English",
+    "fr": "Français",
+    "de": "Deutsch"
 }
 ```
 
@@ -72,11 +72,11 @@ The `<i18n-switcher>` component provides a dropdown for locale switching with cu
 
 ```vue
 <template>
-  <div>
-    <i18n-switcher
-      :custom-labels="{ en: 'English', fr: 'Français', de: 'Deutsch' }"
-    />
-  </div>
+    <div>
+        <i18n-switcher
+            :custom-labels="{ en: 'English', fr: 'Français', de: 'Deutsch' }"
+        />
+    </div>
 </template>
 ```
 
@@ -86,16 +86,16 @@ The `<i18n-link>` component automatically handles locale-specific routing:
 
 ```vue
 <template>
-  <div>
-    <i18n-link to="/about">{{ $t('about') }}</i18n-link>
-    <i18n-link :to="{ name: 'index' }">{{ $t('home') }}</i18n-link>
-  </div>
+    <div>
+        <i18n-link to="/about">{{ $t('about') }}</i18n-link>
+        <i18n-link :to="{ name: 'index' }">{{ $t('home') }}</i18n-link>
+    </div>
 </template>
 
 <script setup>
-  import { useNuxtApp } from '#imports'
+import { useNuxtApp } from '#imports'
 
-  const { $getLocale, $switchLocale, $getLocales, $t } = useNuxtApp()
+const { $getLocaleCode, $switchLocale, $getLocales, $t } = useNuxtApp()
 </script>
 ```
 
@@ -103,8 +103,8 @@ The `<i18n-link>` component automatically handles locale-specific routing:
 
 ```json
 {
-  "about": "About Us",
-  "home": "Home"
+    "about": "About Us",
+    "home": "Home"
 }
 ```
 
@@ -112,9 +112,9 @@ The `<i18n-link>` component automatically handles locale-specific routing:
 
 ```vue
 <template>
-  <div>
-    <i18n-link to="/about" activeClass="current">About Us</i18n-link>
-  </div>
+    <div>
+        <i18n-link to="/about" activeClass="current">About Us</i18n-link>
+    </div>
 </template>
 ```
 
@@ -132,14 +132,13 @@ This example fetches an array of keys from a specific translation path (in this 
 
 ```vue
 <template>
-  <div>
-    <div
-      v-for="key in $t('dynamic')"
-      :key="key"
-    >
-      <p>{{ key }}: <span v-if="$has(key)">{{ $t(key) }}</span></p>
+    <div>
+        <div v-for="key in $t('dynamic')" :key="key">
+            <p>
+                {{ key }}: <span v-if="$has(key)">{{ $t(key) }}</span>
+            </p>
+        </div>
     </div>
-  </div>
 </template>
 
 <script setup>
@@ -153,10 +152,10 @@ const { $t, $has } = useNuxtApp()
 
 ```json
 {
-  "dynamic": ["key1", "key2", "key3"],
-  "key1": "This is the first key's value",
-  "key2": "This is the second key's value",
-  "key3": "This is the third key's value"
+    "dynamic": ["key1", "key2", "key3"],
+    "key1": "This is the first key's value",
+    "key2": "This is the second key's value",
+    "key3": "This is the third key's value"
 }
 ```
 
@@ -166,11 +165,11 @@ In this example, we handle an object stored within your translation file. We fet
 
 ```vue
 <template>
-  <div>
-    <div v-for="(value, key) in $t('dynamicObject')" :key="key">
-      <p>{{ key }}: {{ value }}</p>
+    <div>
+        <div v-for="(value, key) in $t('dynamicObject')" :key="key">
+            <p>{{ key }}: {{ value }}</p>
+        </div>
     </div>
-  </div>
 </template>
 
 <script setup>
@@ -184,11 +183,11 @@ const { $t } = useNuxtApp()
 
 ```json
 {
-  "dynamicObject": {
-    "title": "Welcome to our site",
-    "description": "This is a brief description of our services.",
-    "footerNote": "Thank you for visiting!"
-  }
+    "dynamicObject": {
+        "title": "Welcome to our site",
+        "description": "This is a brief description of our services.",
+        "footerNote": "Thank you for visiting!"
+    }
 }
 ```
 
@@ -198,11 +197,12 @@ The `<i18n-t>` component is useful for rendering translations with dynamic conte
 
 ```vue
 <template>
-  <i18n-t keypath="greeting" tag="h1">
-    <template #default="{ translation }">
-      <strong>{{ translation.replace('page', 'page replace') }}</strong> <i>!!!</i>
-    </template>
-  </i18n-t>
+    <i18n-t keypath="greeting" tag="h1">
+        <template #default="{ translation }">
+            <strong>{{ translation.replace('page', 'page replace') }}</strong>
+            <i>!!!</i>
+        </template>
+    </i18n-t>
 </template>
 ```
 
@@ -210,7 +210,7 @@ The `<i18n-t>` component is useful for rendering translations with dynamic conte
 
 ```json
 {
-  "greeting": "Welcome to the page"
+    "greeting": "Welcome to the page"
 }
 ```
 
@@ -218,7 +218,10 @@ The `<i18n-t>` component is useful for rendering translations with dynamic conte
 
 ```vue
 <template>
-  <i18n-t keypath="welcome" :params="{ username: 'Alice', unreadCount: 5 }"></i18n-t>
+    <i18n-t
+        keypath="welcome"
+        :params="{ username: 'Alice', unreadCount: 5 }"
+    ></i18n-t>
 </template>
 ```
 
@@ -226,7 +229,7 @@ The `<i18n-t>` component is useful for rendering translations with dynamic conte
 
 ```json
 {
-  "welcome": "Hello {username}, you have {unreadCount} unread messages."
+    "welcome": "Hello {username}, you have {unreadCount} unread messages."
 }
 ```
 
@@ -236,63 +239,71 @@ Here's a complex structure demonstrating multiple translation uses within a sing
 
 ```vue
 <template>
-  <div>
-    <h1>{{ $t('mainHeader') }}</h1>
-
-    <nav>
-      <ul>
-        <li><a href="#">{{ $t('nav.home') }}</a></li>
-        <li><a href="#">{{ $t('nav.about') }}</a></li>
-        <li><a href="#">{{ $t('nav.services') }}</a></li>
-        <li><a href="#">{{ $t('nav.contact') }}</a></li>
-      </ul>
-    </nav>
-
-    <section>
-      <h2>{{ $t('section1.header') }}</h2>
-      <p>{{ $t('section1.intro') }}</p>
-
-      <div>
-        <h3>{{ $t('section1.subsection1.header') }}</h3>
-        <p>{{ $t('section1.subsection1.content') }}</p>
-      </div>
-
-      <div>
-        <h3>{{ $t('section1.subsection2.header') }}</h3>
-        <ul>
-          <li>{{ $t('section1.subsection2.item1') }}</li>
-          <li>{{ $t('section1.subsection2.item2') }}</li>
-          <li>{{ $t('section1.subsection2.item3') }}</li>
-        </ul>
-      </div>
-    </section>
-
-    <footer>
-      <h4>{{ $t('footer.contact.header') }}</h4>
-      <address>
-        {{ $t('footer.contact.address') }}<br>
-        {{ $t('footer.contact.city') }}<br>
-        {{ $t('footer.contact.phone') }}
-      </address>
-    </footer>
-
     <div>
-      <button
-        v-for="locale in $getLocales()"
-        :key="locale.code"
-        :disabled="locale.code === $getLocale()"
-        @click="() => $switchLocale(locale.code)"
-      >
-        Switch to {{ locale.code }}
-      </button>
+        <h1>{{ $t('mainHeader') }}</h1>
+
+        <nav>
+            <ul>
+                <li>
+                    <a href="#">{{ $t('nav.home') }}</a>
+                </li>
+                <li>
+                    <a href="#">{{ $t('nav.about') }}</a>
+                </li>
+                <li>
+                    <a href="#">{{ $t('nav.services') }}</a>
+                </li>
+                <li>
+                    <a href="#">{{ $t('nav.contact') }}</a>
+                </li>
+            </ul>
+        </nav>
+
+        <section>
+            <h2>{{ $t('section1.header') }}</h2>
+            <p>{{ $t('section1.intro') }}</p>
+
+            <div>
+                <h3>{{ $t('section1.subsection1.header') }}</h3>
+                <p>{{ $t('section1.subsection1.content') }}</p>
+            </div>
+
+            <div>
+                <h3>{{ $t('section1.subsection2.header') }}</h3>
+                <ul>
+                    <li>{{ $t('section1.subsection2.item1') }}</li>
+                    <li>{{ $t('section1.subsection2.item2') }}</li>
+                    <li>{{ $t('section1.subsection2.item3') }}</li>
+                </ul>
+            </div>
+        </section>
+
+        <footer>
+            <h4>{{ $t('footer.contact.header') }}</h4>
+            <address>
+                {{ $t('footer.contact.address') }}<br />
+                {{ $t('footer.contact.city') }}<br />
+                {{ $t('footer.contact.phone') }}
+            </address>
+        </footer>
+
+        <div>
+            <button
+                v-for="locale in $getLocales()"
+                :key="locale.code"
+                :disabled="locale.code === $getLocaleCode()"
+                @click="() => $switchLocale(locale.code)"
+            >
+                Switch to {{ locale.code }}
+            </button>
+        </div>
     </div>
-  </div>
 </template>
 
 <script setup>
 import { useNuxtApp } from '#imports'
 
-const { $getLocale, $switchLocale, $getLocales, $t } = useNuxtApp()
+const { $getLocaleCode, $switchLocale, $getLocales, $t } = useNuxtApp()
 </script>
 ```
 
@@ -300,40 +311,37 @@ const { $getLocale, $switchLocale, $getLocales, $t } = useNuxtApp()
 
 ```json
 {
-  "mainHeader": "Welcome to Our Services",
-  "nav": {
-    "home": "Home",
-    "about": "About Us",
-    "services": "Services",
-    "contact": "Contact"
-  },
-  "section1": {
-    "header": "Our Expertise",
-    "intro": "We provide a wide range of services to meet your needs.",
-    "subsection1": {
-      "header": "Consulting",
-      "content": "Our team offers expert consulting services in various domains."
+    "mainHeader": "Welcome to Our Services",
+    "nav": {
+        "home": "Home",
+        "about": "About Us",
+        "services": "Services",
+        "contact": "Contact"
     },
-    "subsection2": {
-      "header": "Development",
-      "item1":
-
- "Web Development",
-      "item2": "Mobile Apps",
-      "item3": "Custom Software"
+    "section1": {
+        "header": "Our Expertise",
+        "intro": "We provide a wide range of services to meet your needs.",
+        "subsection1": {
+            "header": "Consulting",
+            "content": "Our team offers expert consulting services in various domains."
+        },
+        "subsection2": {
+            "header": "Development",
+            "item1": "Web Development",
+            "item2": "Mobile Apps",
+            "item3": "Custom Software"
+        }
+    },
+    "footer": {
+        "contact": {
+            "header": "Contact Us",
+            "address": "123 Main Street",
+            "city": "Anytown, USA",
+            "phone": "+1 (555) 123-4567"
+        }
     }
-  },
-  "footer": {
-    "contact": {
-      "header": "Contact Us",
-      "address": "123 Main Street",
-      "city": "Anytown, USA",
-      "phone": "+1 (555) 123-4567"
-    }
-  }
 }
 ```
-
 
 ## 🌟 Using `$tc` for Pluralization
 
@@ -345,12 +353,15 @@ In the following example, we display a message indicating the number of apples u
 
 ```vue
 <template>
-  <div>
-    <!-- Display a pluralized message about the number of apples -->
-    <p>{{ $tc('apples', 0) }}</p>  <!-- Outputs: no apples -->
-    <p>{{ $tc('apples', 1) }}</p>  <!-- Outputs: one apple -->
-    <p>{{ $tc('apples', 10) }}</p> <!-- Outputs: 10 apples -->
-  </div>
+    <div>
+        <!-- Display a pluralized message about the number of apples -->
+        <p>{{ $tc('apples', 0) }}</p>
+        <!-- Outputs: no apples -->
+        <p>{{ $tc('apples', 1) }}</p>
+        <!-- Outputs: one apple -->
+        <p>{{ $tc('apples', 10) }}</p>
+        <!-- Outputs: 10 apples -->
+    </div>
 </template>
 
 <script setup>
@@ -366,15 +377,15 @@ Here's how you can define the translation in your JSON file to handle different 
 
 ```json
 {
-  "apples": "no apples | one apple | {count} apples"
+    "apples": "no apples | one apple | {count} apples"
 }
 ```
 
 ### Explanation
 
-- **`$tc('apples', 0)`**: Returns the first form, used when the count is zero (`"no apples"`).
-- **`$tc('apples', 1)`**: Returns the second form, used when the count is one (`"one apple"`).
-- **`$tc('apples', 10)`**: Returns the third form with the count value, used when the count is two or more (`"10 apples"`).
+-   **`$tc('apples', 0)`**: Returns the first form, used when the count is zero (`"no apples"`).
+-   **`$tc('apples', 1)`**: Returns the second form, used when the count is one (`"one apple"`).
+-   **`$tc('apples', 10)`**: Returns the third form with the count value, used when the count is two or more (`"10 apples"`).
 
 ### Additional Example with More Complex Pluralization
 
@@ -382,13 +393,12 @@ If your application needs to handle more complex pluralization rules (e.g., spec
 
 ```json
 {
-  "apples": "no apples | one apple | two apples | a few apples | many apples | {count} apples"
+    "apples": "no apples | one apple | two apples | a few apples | many apples | {count} apples"
 }
 ```
 
-- **`$tc('apples', 2)`**: Could be set up to return `"two apples"`.
-- **`$tc('apples', 3)`**: Could return `"a few apples"`, depending on the rules defined for the count.
-
+-   **`$tc('apples', 2)`**: Could be set up to return `"two apples"`.
+-   **`$tc('apples', 3)`**: Could return `"a few apples"`, depending on the rules defined for the count.
 
 ## 🌐 Using `$tn` for Number Formatting
 
@@ -398,13 +408,15 @@ The `$tn` function formats numbers according to the current locale using the `In
 
 ```vue
 <template>
-  <div>
-    <!-- Format a number as currency -->
-    <p>{{ $tn(1234567.89, { style: 'currency', currency: 'USD' }) }}</p> <!-- Outputs: $1,234,567.89 in 'en-US' locale -->
+    <div>
+        <!-- Format a number as currency -->
+        <p>{{ $tn(1234567.89, { style: 'currency', currency: 'USD' }) }}</p>
+        <!-- Outputs: $1,234,567.89 in 'en-US' locale -->
 
-    <!-- Format a number with custom options -->
-    <p>{{ $tn(0.567, { style: 'percent', minimumFractionDigits: 1 }) }}</p> <!-- Outputs: 56.7% in 'en-US' locale -->
-  </div>
+        <!-- Format a number with custom options -->
+        <p>{{ $tn(0.567, { style: 'percent', minimumFractionDigits: 1 }) }}</p>
+        <!-- Outputs: 56.7% in 'en-US' locale -->
+    </div>
 </template>
 
 <script setup>
@@ -424,13 +436,32 @@ The `$td` function formats dates and times according to the current locale using
 
 ```vue
 <template>
-  <div>
-    <!-- Format a date with full options -->
-    <p>{{ $td(new Date(), { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' }) }}</p> <!-- Outputs: "Friday, September 1, 2023" in 'en-US' locale -->
+    <div>
+        <!-- Format a date with full options -->
+        <p>
+            {{
+                $td(new Date(), {
+                    weekday: 'long',
+                    year: 'numeric',
+                    month: 'long',
+                    day: 'numeric'
+                })
+            }}
+        </p>
+        <!-- Outputs: "Friday, September 1, 2023" in 'en-US' locale -->
 
-    <!-- Format a date with time -->
-    <p>{{ $td(new Date(), { hour: '2-digit', minute: '2-digit', second: '2-digit' }) }}</p> <!-- Outputs: "10:15:30 AM" in 'en-US' locale -->
-  </div>
+        <!-- Format a date with time -->
+        <p>
+            {{
+                $td(new Date(), {
+                    hour: '2-digit',
+                    minute: '2-digit',
+                    second: '2-digit'
+                })
+            }}
+        </p>
+        <!-- Outputs: "10:15:30 AM" in 'en-US' locale -->
+    </div>
 </template>
 
 <script setup>

--- a/docs/guide/custom-locale-routes.md
+++ b/docs/guide/custom-locale-routes.md
@@ -18,17 +18,17 @@ Here’s an example of how you might define custom routes for specific locales u
 
 ```typescript
 $defineI18nRoute({
-  localeRoutes: {
-    ru: '/localesubpage', // Custom route path for the Russian locale
-    de: '/lokaleseite',   // Custom route path for the German locale
-  },
+    localeRoutes: {
+        ru: '/localesubpage', // Custom route path for the Russian locale
+        de: '/lokaleseite' // Custom route path for the German locale
+    }
 })
 ```
 
 ### 🔄 How `localeRoutes` Work
 
-- **Default Behavior**: Without `localeRoutes`, all locales use a common route structure defined by the primary path.
-- **Custom Behavior**: With `localeRoutes`, specific locales can have their own routes, overriding the default path with locale-specific routes defined in the configuration.
+-   **Default Behavior**: Without `localeRoutes`, all locales use a common route structure defined by the primary path.
+-   **Custom Behavior**: With `localeRoutes`, specific locales can have their own routes, overriding the default path with locale-specific routes defined in the configuration.
 
 ## 🌱 Use Cases for `localeRoutes`
 
@@ -38,45 +38,45 @@ Here’s a simple Vue component demonstrating the use of `$defineI18nRoute` with
 
 ```vue
 <template>
-  <div>
-    <!-- Display greeting message based on the current locale -->
-    <p>{{ $t('greeting') }}</p>
-
-    <!-- Navigation links -->
     <div>
-      <NuxtLink :to="$localeRoute({ name: 'index' })">
-        Go to Index
-      </NuxtLink>
-      |
-      <NuxtLink :to="$localeRoute({ name: 'about' })">
-        Go to About Page
-      </NuxtLink>
+        <!-- Display greeting message based on the current locale -->
+        <p>{{ $t('greeting') }}</p>
+
+        <!-- Navigation links -->
+        <div>
+            <NuxtLink :to="$localeRoute({ name: 'index' })">
+                Go to Index
+            </NuxtLink>
+            |
+            <NuxtLink :to="$localeRoute({ name: 'about' })">
+                Go to About Page
+            </NuxtLink>
+        </div>
     </div>
-  </div>
 </template>
 
 <script setup>
 import { useNuxtApp } from '#imports'
 
-const { $getLocale, $switchLocale, $getLocales, $localeRoute, $t, $defineI18nRoute } = useNuxtApp()
+const { $switchLocale, $localeRoute, $t, $defineI18nRoute } = useNuxtApp()
 
 // Define translations and custom routes for specific locales
 $defineI18nRoute({
-  localeRoutes: {
-    ru: '/localesubpage', // Custom route path for Russian locale
-  },
+    localeRoutes: {
+        ru: '/localesubpage' // Custom route path for Russian locale
+    }
 })
 </script>
 ```
 
 ### 🛠️ Using `localeRoutes` in Different Contexts
 
-- **Landing Pages**: Use custom routes to localize URLs for landing pages, ensuring they align with marketing campaigns.
-- **Documentation Sites**: Provide distinct routes for each locale to better match the localized content structure.
-- **E-commerce Sites**: Tailor product or category URLs per locale for improved SEO and user experience.
+-   **Landing Pages**: Use custom routes to localize URLs for landing pages, ensuring they align with marketing campaigns.
+-   **Documentation Sites**: Provide distinct routes for each locale to better match the localized content structure.
+-   **E-commerce Sites**: Tailor product or category URLs per locale for improved SEO and user experience.
 
 ## 📝 Best Practices for Using `localeRoutes`
 
-- **🚀 Use for Relevant Locales**: Apply `localeRoutes` primarily where the URL structure significantly impacts the user experience or SEO. Avoid overuse for minor differences.
-- **🔧 Maintain Consistency**: Keep a consistent routing pattern across locales unless there's a strong reason to deviate. This approach helps in maintaining clarity and reducing complexity.
-- **📚 Document Custom Routes**: Clearly document any custom routes you define with `localeRoutes`, especially in modular applications, to ensure team members understand the routing logic.
+-   **🚀 Use for Relevant Locales**: Apply `localeRoutes` primarily where the URL structure significantly impacts the user experience or SEO. Avoid overuse for minor differences.
+-   **🔧 Maintain Consistency**: Keep a consistent routing pattern across locales unless there's a strong reason to deviate. This approach helps in maintaining clarity and reducing complexity.
+-   **📚 Document Custom Routes**: Clearly document any custom routes you define with `localeRoutes`, especially in modular applications, to ensure team members understand the routing logic.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nuxt-i18n-micro",
-  "version": "1.21.5",
+  "version": "1.22.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nuxt-i18n-micro",
-      "version": "1.21.5",
+      "version": "1.22.1",
       "license": "MIT",
       "workspaces": [
         "client",

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -27,9 +27,9 @@ export default defineNuxtConfig({
   ],
   i18n: {
     locales: [
-      { code: 'en', iso: 'en_EN' },
-      { code: 'de', iso: 'de_DE' },
-      { code: 'ru', iso: 'ru_RU' },
+      { code: 'en', iso: 'en_EN', displayName: 'English' },
+      { code: 'de', iso: 'de_DE', displayName: 'German' },
+      { code: 'ru', iso: 'ru_RU', displayName: 'Russian' },
     ],
     meta: true,
     defaultLocale: 'en',

--- a/playground/pages/index.vue
+++ b/playground/pages/index.vue
@@ -1,10 +1,11 @@
 <template>
   <div>
-    <p>{{ $t('key1.key1.key1.key1.key1') }}</p>
+    <p>{{ $t("key1.key1.key1.key1.key1") }}</p>
     <p>Current Locale: {{ $getLocale() }}</p>
     <p>Current route without locale: {{ $getRouteName() }}</p>
 
     <!-- Ссылки для переключения локалей -->
+    <h1>Switch locale</h1>
     <div>
       <button
         v-for="locale in $getLocales()"
@@ -15,30 +16,43 @@
         Switch to {{ locale.code }}
       </button>
     </div>
-
+    <h1>localized route</h1>
     <p id="localized-route">
-      {{ $localeRoute({ name: 'page' }, 'de').path }}
+      {{ $localeRoute({ name: "page" }, "de").path }}
     </p>
 
+    <h1>Display name</h1>
+    <p
+      v-for="(locale, index) of $getLocales()"
+      :key="index"
+    >
+      {{ locale.displayName }}
+    </p>
+    <h1>Tests for {{ "<a></a>" }} and {{ "<nuxt-link></nuxt-link>" }} tags</h1>
     <div>
-      <i18n-link :to="{ name: 'page' }">
-        Go to Page
+      <i18n-link
+        style="margin-right: 24px"
+        :to="{ name: 'page' }"
+      >
+        NuxtLink
       </i18n-link>
+
+      <a href="/">tag a</a>
     </div>
 
-    <a href="/">test</a>
-
-    <div>
+    <h1>Dynamic translation by passing variables</h1>
+    <p>
       <i18n-switcher
         :custom-labels="{ en: 'English', de: 'Deutsch', ru: 'Русский' }"
       />
-    </div>
-
+    </p>
     <div
       v-for="key in generatedKeys"
       :key="key"
     >
-      <p>{{ key }}: <span v-if="$has(key)">{{ $t(key) }}</span></p>
+      <p>
+        {{ key }}: <span v-if="$has(key)">{{ $t(key) }}</span>
+      </p>
     </div>
   </div>
 </template>

--- a/playground/pages/index.vue
+++ b/playground/pages/index.vue
@@ -2,6 +2,8 @@
   <div>
     <p>{{ $t("key1.key1.key1.key1.key1") }}</p>
     <p>Current Locale: {{ $getLocale() }}</p>
+    <p>Current locale code: {{ $getLocaleCode() }}</p>
+    <p>Current locale display name: {{ $getLocale().displayName }}</p>
     <p>Current route without locale: {{ $getRouteName() }}</p>
 
     <!-- Ссылки для переключения локалей -->
@@ -10,7 +12,7 @@
       <button
         v-for="locale in $getLocales()"
         :key="locale.code"
-        :disabled="locale.code === $getLocale()"
+        :disabled="locale.code === $getLocaleCode()"
         @click="() => $switchLocale(locale.code)"
       >
         Switch to {{ locale.code }}

--- a/src/runtime/components/i18n-switcher.vue
+++ b/src/runtime/components/i18n-switcher.vue
@@ -6,7 +6,9 @@
       @click="toggleDropdown"
     >
       {{ currentLocaleLabel }}
-      <span :style="[iconStyle, dropdownOpen ? openIconStyle : {}, customIconStyle]">&#9662;</span>
+      <span
+        :style="[iconStyle, dropdownOpen ? openIconStyle : {}, customIconStyle]"
+      >&#9662;</span>
     </button>
     <ul
       v-if="dropdownOpen"
@@ -20,7 +22,12 @@
         <NuxtLink
           :class="`switcher-locale-${locale.code}`"
           :to="getLocaleLink(locale)"
-          :style="[linkStyle, locale.code === currentLocale ? activeLinkStyle : {}, locale.code === currentLocale ? disabledLinkStyle : {}, customLinkStyle]"
+          :style="[
+            linkStyle,
+            locale.code === currentLocale.code ? activeLinkStyle : {},
+            locale.code === currentLocale.code ? disabledLinkStyle : {},
+            customLinkStyle,
+          ]"
           :hreflang="locale.iso || locale.code"
           @click="toggleDropdown"
         >
@@ -77,14 +84,22 @@ const toggleDropdown = () => {
 }
 
 const localeLabel = (locale: Locale) => {
-  return props.customLabels[locale.code] || locale.code.toUpperCase()
+  return (
+    (props.customLabels[locale.code] || locale.displayName)
+    ?? console.warn(
+      '[i18n-switcher] Either define a custom label for the locale or provide a displayName in the nuxt.config.ts[i18n]',
+    )
+  )
 }
 
-const currentLocaleLabel = computed(() => localeLabel({ code: currentLocale.value }))
+const currentLocaleLabel = computed(() =>
+  localeLabel({ ...currentLocale.value }),
+)
 
 const getLocaleLink = (locale: Locale) => {
   const route = useRoute()
-  const routeName = (route?.name ?? '').toString()
+  const routeName = (route?.name ?? '')
+    .toString()
     .replace(`localized-`, '')
     .replace(new RegExp(`-${currentLocale.value}$`), '')
     .replace(new RegExp(`-${locale}$`), '')

--- a/src/runtime/composables/useI18n.ts
+++ b/src/runtime/composables/useI18n.ts
@@ -6,6 +6,7 @@ export function useI18n(): PluginsInjections {
 
   return {
     $defaultLocale: nuxtApp.$defaultLocale,
+    $getLocaleCode: nuxtApp.$getLocaleCode,
     $getLocale: nuxtApp.$getLocale,
     $getLocales: nuxtApp.$getLocales,
     $getRouteName: nuxtApp.$getRouteName,

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,7 @@ export interface Locale {
   disabled?: boolean
   iso?: string
   dir?: 'ltr' | 'rtl' | 'auto'
+  displayName?: string
 }
 
 export interface DefineI18nRouteConfig {


### PR DESCRIPTION
closes #33 

exposes $getLocaleCode that what current locale code is, replaces $getLocale.

$getLocale is now return a Locale type, for example
{ "code": "en", "iso": "en-US", "dir": "ltr", "displayName": "English" }