### PR TITLE
[Enhancement] Add a new property displayName to type Locale for better accessbility

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -15,9 +15,9 @@ export default defineNuxtConfig({
   modules: ['nuxt-i18n-micro'],
   i18n: {
     locales: [
-      { code: 'en', iso: 'en-US', dir: 'ltr' },
-      { code: 'fr', iso: 'fr-FR', dir: 'ltr' },
-      { code: 'de', iso: 'de-DE', dir: 'ltr' },
+      { code: 'en', iso: 'en-US', dir: 'ltr', disabled: false, displayName: 'English' },
+      { code: 'fr', iso: 'fr-FR', dir: 'ltr', disabled: false, displayName: 'Français' },
+      { code: 'de', iso: 'de-DE', dir: 'ltr', disabled: false, displayName: 'Deutsch' },
     ],
     defaultLocale: 'en',
     translationDir: 'locales',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nuxt-i18n-micro",
-  "version": "1.21.5",
+  "version": "1.23.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nuxt-i18n-micro",
-      "version": "1.21.5",
+      "version": "1.23.1",
       "license": "MIT",
       "workspaces": [
         "client",

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,7 +5,7 @@ export interface Locale {
   disabled?: boolean
   iso?: string
   dir?: 'ltr' | 'rtl' | 'auto'
-  displayName: string
+  displayName?: string
 }
 
 export interface DefineI18nRouteConfig {

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,7 @@ export interface Locale {
   disabled?: boolean
   iso?: string
   dir?: 'ltr' | 'rtl' | 'auto'
+  displayName: string
 }
 
 export interface DefineI18nRouteConfig {


### PR DESCRIPTION
part of #34 

The property `displayName` should be the name of the language from native speakers, written in their native languages, making it more accessile and friendly to users

e.g.

Better
- English
- Русский язык
- Français
- Deutsch
- 简体中文
- 한국어

When written in English, they are good still but isn't the best option
- English
- Russian
- French
- German
- Chinese
- Korea