### PR TITLE
feat: add params to plural translation

### DIFF
--- a/docs/api/methods.md
+++ b/docs/api/methods.md
@@ -90,7 +90,7 @@ const welcomeMessage = $ts('welcome', { username: 'Alice', unreadCount: 5 })
 -   **Description**: Fetches a pluralized translation for the given key based on the count.
 -   **Parameters**:
     - **key**: `string` — The translation key.
-    - **count**: `number` — The count for pluralization.
+    - **params**: `number | Record<string, any>` — The count for pluralization or a record of key-value pairs with a 'count' property and additional values to interpolate into the translation.
     - **defaultValue**: `string | undefined` — Optional. The default value to return if the translation is not found.
 -   **Example**:
 ```typescript

--- a/docs/components/i18n-t.md
+++ b/docs/components/i18n-t.md
@@ -83,7 +83,7 @@ The `<i18n-t>` component in `Nuxt I18n Micro` is a flexible translation componen
   
 ### `customPluralRule`
 
-- **Type**: `(value: string, count: number, locale: string) => string`
+- **Type**: `(value: string, count: number, params: Record<string, string | number | boolean>, locale: string) => string`
 - **Optional**: Yes
 - **Description**: A function that allows you to define custom pluralization logic. Useful if the default pluralization rules do not fit your specific needs.
 - **Example**:
@@ -91,8 +91,8 @@ The `<i18n-t>` component in `Nuxt I18n Micro` is a flexible translation componen
   <i18n-t
     keypath="items"
     :plural="itemCount"
-    :customPluralRule="(key, count, locale, getTranslation) => {
-      const translation = getTranslation(key, {})
+    :customPluralRule="(key, count, params, locale, getTranslation) => {
+      const translation = getTranslation(key, params)
       if (!translation) {
         return null
       }

--- a/internals.d.ts
+++ b/internals.d.ts
@@ -1,7 +1,7 @@
 declare module '#build/i18n.plural.mjs' {
-  export function plural(key: string, count: number, locale: string, getter: Getter): string | null
+  export function plural(key: string, count: number, params: Params, locale: string, getter: Getter): string | null
 }
 
 declare module '#internal/i18n/options.mjs' {
-  export function plural(key: string, count: number, locale: string, getter: Getter): string | null
+  export function plural(key: string, count: number, params: Params, locale: string, getter: Getter): string | null
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nuxt-i18n-micro",
-  "version": "1.32.1",
+  "version": "1.32.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nuxt-i18n-micro",
-      "version": "1.32.1",
+      "version": "1.32.4",
       "license": "MIT",
       "workspaces": [
         "client",

--- a/playground/locales/pages/page/en.json
+++ b/playground/locales/pages/page/en.json
@@ -1,6 +1,7 @@
 {
   "welcome": "Welcome, {username}! You have {unreadCount} unread messages.  {username}  {username}  {username}",
   "apples": "no apples | one apple | {count} apples",
+  "user_apples": "{username} has no apple|{username} has one apple|{username} has {count} apples",
   "feedback": {
     "text":  "test link: {link}",
     "link":  "click"

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -62,8 +62,8 @@ export default defineNuxtConfig({
       // pages/unlocalized.vue
       'unlocalized': false,
     },
-    plural: (key, count, _locale, getTranslation) => {
-      const translation = getTranslation(key, {})
+    plural: (key, count, params, _locale, getTranslation) => {
+      const translation = getTranslation(key, params)
       if (!translation) {
         return null
       }

--- a/playground/pages/page.vue
+++ b/playground/pages/page.vue
@@ -53,10 +53,29 @@
     </div>
 
     <div>
+      $tc plural with params :
+      <ul>
+        <li>{{ $tc('user_apples', { count: 0, username: 'Alice' }) }}</li>
+        <li>{{ $tc('user_apples', { count: 1, username: 'Alice' }) }}</li>
+        <li>{{ $tc('user_apples', { count: 10, username: 'Alice' }) }}</li>
+      </ul>
+    </div>
+
+    <div>
       i18n-t plural
       <i18n-t
         keypath="apples"
         :plural="appleCount"
+        :custom-plural-rule="customPluralRule"
+      />
+    </div>
+
+    <div>
+      i18n-t plural with params
+      <i18n-t
+        keypath="user_apples"
+        :plural="appleCount"
+        :params="{ username: 'Alice' }"
         :custom-plural-rule="customPluralRule"
       />
     </div>
@@ -101,6 +120,7 @@
 import { useNuxtApp } from '#imports'
 
 type Getter = (key: string, params?: Record<string, string | number | boolean>, defaultValue?: string) => unknown
+type Params = Record<string, string | number | boolean>
 
 const { $getLocale, $switchLocale, $getLocales, $localeRoute, $t, $tc, $tn, $td } = useNuxtApp()
 
@@ -109,8 +129,8 @@ const appleCount = ref(5)
 const locale = computed(() => $getLocale())
 
 // Кастомное правило множественных форм
-const customPluralRule = (key: string, count: number, _locale: string, t: Getter) => {
-  const translation = t(key)
+const customPluralRule = (key: string, count: number, params: Params, _locale: string, t: Getter) => {
+  const translation = t(key, params)
   if (!translation) {
     return null
   }

--- a/src/module.ts
+++ b/src/module.ts
@@ -78,8 +78,8 @@ export default defineNuxtModule<ModuleOptions>({
     apiBaseUrl: '_locales',
     routesLocaleLinks: {},
     globalLocaleRoutes: {},
-    plural: (key, count, _locale, getTranslation) => {
-      const translation = getTranslation(key, {})
+    plural: (key, count, params, _locale, getTranslation) => {
+      const translation = getTranslation(key, params)
       if (!translation) {
         return null
       }

--- a/src/runtime/components/i18n-t.vue
+++ b/src/runtime/components/i18n-t.vue
@@ -47,16 +47,18 @@ export default defineComponent({
       const { $getLocale, $t, $tc } = useNuxtApp().$i18n as PluginsInjections
 
       if (props.plural !== undefined) {
+        const count = Number.parseInt(props.plural.toString())
         if (props.customPluralRule) {
           return h(props.tag, { ...attrs, innerHTML: props.customPluralRule(
             props.keypath,
-            Number.parseInt((props.plural).toString()),
+            count,
+            props.params,
             $getLocale(),
             $t,
           ) })
         }
         else {
-          return h(props.tag, { ...attrs, innerHTML: $tc(props.keypath, Number.parseInt(props.plural.toString())) })
+          return h(props.tag, { ...attrs, innerHTML: $tc(props.keypath, { count, ...props.params }) })
         }
       }
 

--- a/src/runtime/plugins/01.plugin.ts
+++ b/src/runtime/plugins/01.plugin.ts
@@ -8,7 +8,7 @@ import type {
   Router,
 } from 'vue-router'
 import { useTranslationHelper } from '../translationHelper'
-import type { ModuleOptionsExtend, Locale, I18nRouteParams } from '../../types'
+import type { ModuleOptionsExtend, Locale, I18nRouteParams, Params } from '../../types'
 import { defineNuxtPlugin, useRuntimeConfig } from '#app'
 import { useRouter, useCookie, useState, navigateTo } from '#imports'
 import { plural } from '#build/i18n.plural.mjs'
@@ -26,8 +26,6 @@ type Translation = string | number | boolean | Translations | PluralTranslations
 export interface Translations {
   [key: string]: Translation
 }
-
-type Params = Record<string, string | number | boolean>
 
 function interpolate(template: string, params: Params): string {
   let result = template
@@ -423,10 +421,12 @@ export default defineNuxtPlugin(async (nuxtApp) => {
       const value = getTranslation(key, params, defaultValue)
       return value?.toString() ?? defaultValue ?? key
     },
-    tc: (key: string, count: number, defaultValue?: string): string => {
+    tc: (key: string, params: number | Params, defaultValue?: string): string => {
       const route = router.currentRoute.value
       const currentLocale = getCurrentLocale(route, i18nConfig, hashLocale)
-      return plural(key, count, currentLocale, getTranslation) as string ?? defaultValue ?? key
+      const { count, ..._params } = typeof params === 'number' ? { count: params } : params
+
+      return plural(key, Number.parseInt(count.toString()), _params, currentLocale, getTranslation) as string ?? defaultValue ?? key
     },
     tn: (value: number, options?: Intl.NumberFormatOptions) => {
       const route = router.currentRoute.value
@@ -533,7 +533,7 @@ export interface PluginsInjections {
   $getRouteName: (route?: RouteLocationNormalizedLoaded | RouteLocationResolvedGeneric, locale?: string) => string
   $t: (key: string, params?: Params, defaultValue?: string) => Translation
   $ts: (key: string, params?: Params, defaultValue?: string) => string
-  $tc: (key: string, count: number, defaultValue?: string) => string
+  $tc: (key: string, params: number | Params, defaultValue?: string) => string
   $tn: (value: number, options?: Intl.NumberFormatOptions) => string
   $td: (value: Date | number | string, options?: Intl.DateTimeFormatOptions) => string
   $has: (key: string) => boolean

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,8 +16,10 @@ export interface DefineI18nRouteConfig {
 }
 export type I18nRouteParams = Record<LocaleCode, Record<string, string>> | null
 
+export type Params = Record<string, string | number | boolean>
+
 export type Getter = (key: string, params?: Record<string, string | number | boolean>, defaultValue?: string) => unknown
-export type PluralFunc = (key: string, count: number, locale: string, getter: Getter) => string | null
+export type PluralFunc = (key: string, count: number, params: Params, locale: string, getter: Getter) => string | null
 
 export type GlobalLocaleRoutes = Record<string, Record<LocaleCode, string> | false | boolean> | null | undefined
 


### PR DESCRIPTION
Add support for params in plural translations :

```json
{
"user_apples": "{username} has no apple|{username} has one apple|{username} has {count} apples",
}
```

```javascript
$tc('user_apples', {count: 10, username: 'Alice'})
```
```javascript
<i18n-t
  keypath="user_apples"
  :plural="appleCount"
  :params="{ username: 'Alice' }"
/>
```

