### PR TITLE
fix: plural translation with 2 forms

### DIFF
--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -234,13 +234,7 @@ export type Getter = (key: string, params?: Record<string, string | number | boo
       return key
     }
     const forms = translation.toString().split('|')
-    if (count === 0 && forms.length > 2) {
-      return forms[0].trim() // Case for "no apples"
-    }
-    if (count === 1 && forms.length > 1) {
-      return forms[1].trim() // Case for "one apple"
-    }
-    return (forms.length > 2 ? forms[2].trim() : forms[forms.length - 1].trim()).replace('{count}', count.toString())
+    return (count < forms.length ? forms[count].trim() : forms[forms.length - 1].trim()).replace('{count}', count.toString())
   }
 }
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nuxt-i18n-micro",
-  "version": "1.32.4",
+  "version": "1.33.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nuxt-i18n-micro",
-      "version": "1.32.4",
+      "version": "1.33.0",
       "license": "MIT",
       "workspaces": [
         "client",

--- a/playground/locales/pages/page/en.json
+++ b/playground/locales/pages/page/en.json
@@ -1,6 +1,7 @@
 {
   "welcome": "Welcome, {username}! You have {unreadCount} unread messages.  {username}  {username}  {username}",
   "apples": "no apples | one apple | {count} apples",
+  "many_apples": "no apples | many apples",
   "user_apples": "{username} has no apple|{username} has one apple|{username} has {count} apples",
   "feedback": {
     "text":  "test link: {link}",

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -68,13 +68,7 @@ export default defineNuxtConfig({
         return null
       }
       const forms = translation.toString().split('|')
-      if (count === 0 && forms.length > 2) {
-        return forms[0].trim() // Case for "no apples"
-      }
-      if (count === 1 && forms.length > 1) {
-        return forms[1].trim() // Case for "one apple"
-      }
-      return (forms.length > 2 ? forms[2].trim() : forms[forms.length - 1].trim()).replace('{count}', count.toString())
+      return (count < forms.length ? forms[count].trim() : forms[forms.length - 1].trim()).replace('{count}', count.toString())
     },
   },
   devtools: { enabled: true },

--- a/playground/pages/page.vue
+++ b/playground/pages/page.vue
@@ -41,19 +41,22 @@
     <p>text escaping: {{ $t('text_escaping') }}</p>
 
     <div>
+      <b>$t with params: </b>
       {{ $t('welcome', { username: 'Alice', unreadCount: 5 }) }}
     </div>
+
     <div>
-      {{ $tc('apples', 10) }}
+      <b>$tc 2 forms (zero|many): </b>
+      {{ $tc('many_apples', 0) }} | {{ $tc('many_apples', 3) }}
     </div>
 
     <div>
-      $tc plural
-      {{ $tc('apples', 10) }}
+      <b>$tc 3 forms (zero|one|{count}): </b>
+      {{ $tc('apples', 0) }} | {{ $tc('apples', 1) }} | {{ $tc('apples', 3) }}
     </div>
 
     <div>
-      $tc plural with params :
+      <b>$tc plural with params :</b>
       <ul>
         <li>{{ $tc('user_apples', { count: 0, username: 'Alice' }) }}</li>
         <li>{{ $tc('user_apples', { count: 1, username: 'Alice' }) }}</li>

--- a/src/module.ts
+++ b/src/module.ts
@@ -84,13 +84,7 @@ export default defineNuxtModule<ModuleOptions>({
         return null
       }
       const forms = translation.toString().split('|')
-      if (count === 0 && forms.length > 2) {
-        return forms[0].trim() // Case for "no apples"
-      }
-      if (count === 1 && forms.length > 1) {
-        return forms[1].trim() // Case for "one apple"
-      }
-      return (forms.length > 2 ? forms[2].trim() : forms[forms.length - 1].trim()).replace('{count}', count.toString())
+      return (count < forms.length ? forms[count].trim() : forms[forms.length - 1].trim()).replace('{count}', count.toString())
     },
     customRegexMatcher: undefined,
   },


### PR DESCRIPTION
Fix plural for translations containing only 2 forms :
```json
{
    "zero_many": "no apples | many apples"
}
```