### PR TITLE
Disable auto detectin for ssg

### DIFF
--- a/src/runtime/plugins/04.auto-detect.ts
+++ b/src/runtime/plugins/04.auto-detect.ts
@@ -8,6 +8,9 @@ const parseAcceptLanguage = (acceptLanguage: string) =>
     .map(entry => entry.split(';')[0].trim())
 
 export default defineNuxtPlugin(async (nuxtApp) => {
+  if(import.meta.prerender){
+    return
+  }
   const i18nConfig = nuxtApp.$config.public.i18nConfig as ModuleOptionsExtend
   const date = new Date()
   const userLocaleCookie = useCookie(i18nConfig.localeCookie || 'user-locale', {


### PR DESCRIPTION
I've turned off auto-detection for the ssg build, as it only ever renders redirects for other languages.