### PR TITLE
style(active link): remove "font-weight: bold" on active link

### DIFF
--- a/src/runtime/components/i18n-link.vue
+++ b/src/runtime/components/i18n-link.vue
@@ -39,7 +39,6 @@ const isActive = computed(() => {
 const activeStyle = computed(() => {
   return isActive.value
     ? {
-        fontWeight: 'bold',
         ...props.activeStyle, // Merge with any custom active styles passed as props
       }
     : {}


### PR DESCRIPTION
### Remove Font Weight Bold to active link
Font Weight Bold removed for the active link, to make the library more generic. To avoid changing the style of websites that use the library.
 
Bonne journée, Tristan 