### PR TITLE
refactor(slot i18n link): remove the default wording of the i18n link

### DIFF
--- a/src/runtime/components/i18n-link.vue
+++ b/src/runtime/components/i18n-link.vue
@@ -3,7 +3,7 @@
     :to="$localeRoute(to)"
     :style="activeStyle"
   >
-    <slot>Go to Page</slot>
+    <slot />
   </NuxtLink>
 </template>
 


### PR DESCRIPTION
### Remove default wording link
Remove the label of the active link, to make the library more generic. To avoid modifying of websites that use the library. For example, if I want to make an empty link I can do this.

Bonne journée, Tristan