### PR TITLE
fix: pass `disablePageLocales` to public runtime config

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -141,6 +141,7 @@ export default defineNuxtModule<ModuleOptions>({
       apiBaseUrl: apiBaseUrl,
       isSSG: isSSG,
       customRegexMatcher: options.customRegexMatcher,
+      disablePageLocales: options.disablePageLocales,
     }
 
     // if there is a customRegexMatcher set and all locales don't match the custom matcher, throw error


### PR DESCRIPTION
looks like we are not passing the option across to the plugin (though I also might be missing something!):

https://github.com/s00d/nuxt-i18n-micro/blob/b34d5a108d61047ce2f3437a05ce1b93d9dacb72/src/runtime/plugins/01.plugin.ts#L338-L341