### PR TITLE
feat(external link): add "tel:" and "mailto:" in regex external link

### DIFF
--- a/src/runtime/components/i18n-link.vue
+++ b/src/runtime/components/i18n-link.vue
@@ -36,7 +36,7 @@ const route = useRoute()
 
 const isExternalLink = computed(() => {
   if (typeof props.to === 'string') {
-    return /^(?:https?:\/\/|\/\/|[a-zA-Z0-9-]+\.[a-zA-Z]{2,})/.test(props.to)
+    return /^(?:https?:\/\/|\/\/|[a-zA-Z0-9-]+\.[a-zA-Z]{2,})|tel:|mailto:/.test(props.to)
   }
   return false
 })


### PR DESCRIPTION
Add "tel:" and "mailto:" in regex for external link condition.

Example: 
`<a href="tel:+444444">+444444</a>` or `<a href="mailto:test@mail.com">test@mail.com</a>`