### PR TITLE
fix(seo url - slash): remove end slash for the canonical link

### DIFF
--- a/src/runtime/composables/useLocaleHead.ts
+++ b/src/runtime/composables/useLocaleHead.ts
@@ -60,13 +60,6 @@ export const useLocaleHead = ({ addDirAttribute = true, identifierAttribute = 'i
       fullPath = `/${fullPath}`
     }
 
-    if (!ogUrl.endsWith('/')) {
-      ogUrl += '/'
-    }
-    if (!indexUrl.endsWith('/')) {
-      indexUrl += '/'
-    }
-
     const matchedLocale = locales.find(locale => fullPath.startsWith(`/${locale.code}`))
     if (routeName.startsWith('localized-') && matchedLocale) {
       fullPath = fullPath.slice(matchedLocale.code.length + 1)

--- a/src/runtime/composables/useLocaleHead.ts
+++ b/src/runtime/composables/useLocaleHead.ts
@@ -54,7 +54,7 @@ export const useLocaleHead = ({ addDirAttribute = true, identifierAttribute = 'i
 
     let fullPath = unref(route.fullPath)
     let ogUrl = joinURL(unref(baseUrl), fullPath)
-    let indexUrl = joinURL(unref(baseUrl))
+    const indexUrl = joinURL(unref(baseUrl))
 
     if (!fullPath.startsWith('/')) {
       fullPath = `/${fullPath}`


### PR DESCRIPTION
### Uncessery end slash for canonical link
For example my current URL is `https://test.com/slug` but my canonical link is `<link id="i18n-can" rel="canonical" href="https://test.com/slug/">`
But i want  `<link id="i18n-can" rel="canonical" href="https://test.com/slug">` so as not to destroy my SEO.

Bonne soirée