### PR TITLE
Fix/base and slug alternate link

### DIFF
--- a/src/runtime/composables/useLocaleHead.ts
+++ b/src/runtime/composables/useLocaleHead.ts
@@ -54,7 +54,6 @@ export const useLocaleHead = ({ addDirAttribute = true, identifierAttribute = 'i
 
     let fullPath = unref(route.fullPath)
     let ogUrl = joinURL(unref(baseUrl), fullPath)
-    const indexUrl = joinURL(unref(baseUrl))
 
     if (!fullPath.startsWith('/')) {
       fullPath = `/${fullPath}`

--- a/src/runtime/composables/useLocaleHead.ts
+++ b/src/runtime/composables/useLocaleHead.ts
@@ -110,7 +110,7 @@ export const useLocaleHead = ({ addDirAttribute = true, identifierAttribute = 'i
       ? []
       : alternateLocales.flatMap((loc: Locale) => {
           const href = defaultLocale === loc.code && isPrefixExceptDefaultStrategy(strategy!)
-            ? indexUrl
+            ? joinURL(unref(baseUrl), fullPath)
             : joinURL(unref(baseUrl), loc.code, fullPath)
 
           const links = [{


### PR DESCRIPTION
Hi @s00d 🙂
I see a bug in the ‘alternative link’, I can't see the end of my URL.

Example : My current URL : `www.test.com/test`, my alternate link `<link id="i18n-alternate-fr" rel="alternate" href="www.test.com" hreflang="fr">`

Merci 🚀