### PR TITLE
fix: prefer `nitro.static` over `_generate`

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -105,7 +105,7 @@ export default defineNuxtModule<ModuleOptions>({
   async setup(options, nuxt) {
     const defaultLocale = process.env.DEFAULT_LOCALE ?? options.defaultLocale ?? 'en'
 
-    const isSSG = nuxt.options._generate
+    const isSSG = nuxt.options.nitro.static || (nuxt.options as any)._generate /* TODO: remove in future */
     const isCloudflarePages = nuxt.options.nitro.preset?.startsWith('cloudflare')
 
     const logger = useLogger('nuxt-i18n-micro')

--- a/src/module.ts
+++ b/src/module.ts
@@ -105,7 +105,7 @@ export default defineNuxtModule<ModuleOptions>({
   async setup(options, nuxt) {
     const defaultLocale = process.env.DEFAULT_LOCALE ?? options.defaultLocale ?? 'en'
 
-    const isSSG = nuxt.options.nitro.static || (nuxt.options as any)._generate /* TODO: remove in future */
+    const isSSG = nuxt.options.nitro.static ?? (nuxt.options as any)._generate /* TODO: remove in future */
     const isCloudflarePages = nuxt.options.nitro.preset?.startsWith('cloudflare')
 
     const logger = useLogger('nuxt-i18n-micro')


### PR DESCRIPTION

Since nuxi v3.8, we've supported setting `nuxt.options.nitro.static` instead of `nuxt.options._generate` (which is an internal flag) - see https://github.com/nuxt/nuxt/pull/21860.

Now, in preparation for Nuxt v4, we've removed the types for `_generate` (see https://github.com/nuxt/nuxt/pull/32355). This PR adds support for new version in backwards compatible way (ignoring type issues) - I'd suggest you remove support in a future major.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Updated the code to use `nuxt.options.nitro.static` instead of the internal `_generate` flag for static site detection, with fallback for older versions.

<!-- End of auto-generated description by cubic. -->

