### PR TITLE
feat: remove unstable code

### DIFF
--- a/src/runtime/components/locale-redirect.vue
+++ b/src/runtime/components/locale-redirect.vue
@@ -63,12 +63,6 @@ if (globalLocaleRoutes && globalLocaleRoutes[currentPageName]) {
     }
   }
 }
-else if (!locales.includes(firstSegment)) {
-  const newPath = `/${defaultLocale}${route.fullPath}`
-  if (route.fullPath !== newPath) {
-    handleRedirect(newPath)
-  }
-}
 else if (locales.includes(firstSegment) && globalLocaleRoutes && globalLocaleRoutes[currentLocalePageName]) {
   const localizedRoutes = globalLocaleRoutes[currentLocalePageName]
   if (localizedRoutes && localizedRoutes[firstSegment]) {


### PR DESCRIPTION
[https://github.com/s00d/nuxt-i18n-micro/issues/181](Issue)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the default-locale fallback in locale-redirect to stop unintended redirects and fix incorrect navigation when the URL doesn’t include a locale. Redirects now rely solely on the route map, improving stability.

- **Bug Fixes**
  - Removed the code that auto-prefixed defaultLocale when the first segment wasn’t a locale.
  - Redirects only occur when a matching route exists in globalLocaleRoutes, avoiding loops and false positives.

<sup>Written for commit 43863fd4598e4928781c0be4cb8f8a0b59d4ce7e. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

