### PR TITLE
feat: add messageCompiler

### DIFF
--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -472,6 +472,65 @@ plural: (key, count, _params, _locale, t) => {
 }
 ```
 
+#### `messageCompiler`
+
+Custom function for compiling messages, enabling ICU MessageFormat or other advanced formatting libraries.
+
+**Type**: `(message: string, locale: string, key: string) => (params?: Params) => string`
+
+When provided, this function will be used instead of the default simple interpolation. This allows you to use advanced message formatting libraries like `intl-messageformat` for ICU MessageFormat support.
+
+**Example with intl-messageformat:**
+
+```typescript
+import IntlMessageFormat from 'intl-messageformat'
+
+export default defineNuxtConfig({
+  i18n: {
+    messageCompiler: (message, locale, _key) => {
+      const formatter = new IntlMessageFormat(message, locale)
+      return (params) => formatter.format(params) as string
+    },
+    // ... other options
+  },
+})
+```
+
+**Features:**
+- ✅ **ICU MessageFormat Support**: Use ICU syntax for complex message formatting
+- ✅ **Caching**: Compiled messages are automatically cached for performance
+- ✅ **Automatic Invalidation**: Cache is cleared when locale changes or translations are updated
+- ✅ **Works Everywhere**: Supported in Nuxt, Vue, React, Preact, Solid, Node, and Astro adapters
+
+**ICU MessageFormat Example:**
+
+With `messageCompiler` configured, you can use ICU syntax in your translation files:
+
+```json
+{
+  "welcome": "Welcome, {name}!",
+  "items": "{count, plural, =0 {No items} one {# item} other {# items}}",
+  "gender": "{gender, select, male {He} female {She} other {They}} went to the store"
+}
+```
+
+```vue
+<template>
+  <div>
+    <p>{{ $t('welcome', { name: 'Alice' }) }}</p>
+    <!-- Output: Welcome, Alice! -->
+    
+    <p>{{ $t('items', { count: 5 }) }}</p>
+    <!-- Output: 5 items -->
+    
+    <p>{{ $t('gender', { gender: 'female' }) }}</p>
+    <!-- Output: She went to the store -->
+  </div>
+</template>
+```
+
+**Note:** When `messageCompiler` is set, it will be used for ALL messages, even simple ones. If you need to use simple interpolation for some messages and ICU for others, you can handle this logic within your `messageCompiler` function.
+
 #### `localeCookie`
 
 Specifies the cookie name for storing user's locale.

--- a/docs/integrations/astro-package.md
+++ b/docs/integrations/astro-package.md
@@ -1346,6 +1346,7 @@ Creates and configures the Astro integration for i18n-micro.
 | `locales` | `Locale[]` | ❌ | `[]` | Array of locale objects |
 | `messages` | `Record<string, Translations>` | ❌ | `{}` | Initial translation messages |
 | `plural` | `PluralFunc` | ❌ | `defaultPlural` | Custom pluralization function |
+| `messageCompiler` | `MessageCompilerFunc` | ❌ | - | Custom function for compiling messages (ICU MessageFormat support) |
 | `missingWarn` | `boolean` | ❌ | `false` | Show console warnings for missing translations |
 | `missingHandler` | `(locale: string, key: string, routeName: string) => void` | ❌ | - | Custom handler for missing translations |
 | `localeCookie` | `string` | ❌ | `'i18n-locale'` | Cookie name for storing locale |

--- a/docs/integrations/nodejs-package.md
+++ b/docs/integrations/nodejs-package.md
@@ -64,6 +64,7 @@ Creates a new I18n instance.
 - `fallbackLocale?: string` - Fallback locale (default: same as locale)
 - `translationDir?: string` - Path to locales directory
 - `plural?: PluralFunc` - Custom pluralization function
+- `messageCompiler?: MessageCompilerFunc` - Custom function for compiling messages (ICU MessageFormat support)
 - `missingWarn?: boolean` - Show warnings for missing translations
 - `missingHandler?: (locale: string, key: string, routeName: string) => void` - Custom handler
 

--- a/docs/integrations/preact-package.md
+++ b/docs/integrations/preact-package.md
@@ -331,6 +331,7 @@ Creates a new i18n instance for your Preact application.
 | `fallbackLocale` | `string` | ❌ | Same as `locale` | Fallback locale when translation is missing |
 | `messages` | `Record<string, Translations>` | ❌ | `{}` | Initial translation messages |
 | `plural` | `PluralFunc` | ❌ | `defaultPlural` | Custom pluralization function |
+| `messageCompiler` | `MessageCompilerFunc` | ❌ | - | Custom function for compiling messages (ICU MessageFormat support) |
 | `missingWarn` | `boolean` | ❌ | `false` | Show console warnings for missing translations |
 | `missingHandler` | `(locale: string, key: string, routeName: string) => void` | ❌ | - | Custom handler for missing translations |
 

--- a/docs/integrations/react-package.md
+++ b/docs/integrations/react-package.md
@@ -334,6 +334,7 @@ Creates a new i18n instance for your React application.
 | `fallbackLocale` | `string` | ❌ | Same as `locale` | Fallback locale when translation is missing |
 | `messages` | `Record<string, Translations>` | ❌ | `{}` | Initial translation messages |
 | `plural` | `PluralFunc` | ❌ | `defaultPlural` | Custom pluralization function |
+| `messageCompiler` | `MessageCompilerFunc` | ❌ | - | Custom function for compiling messages (ICU MessageFormat support) |
 | `missingWarn` | `boolean` | ❌ | `false` | Show console warnings for missing translations |
 | `missingHandler` | `(locale: string, key: string, routeName: string) => void` | ❌ | - | Custom handler for missing translations |
 

--- a/docs/integrations/solid-package.md
+++ b/docs/integrations/solid-package.md
@@ -694,6 +694,7 @@ Creates a SolidJS i18n instance.
 | `fallbackLocale` | `string` | ❌ | Same as `locale` | Fallback locale when translation is missing |
 | `messages` | `Record<string, Translations>` | ❌ | `{}` | Initial translation messages |
 | `plural` | `PluralFunc` | ❌ | `defaultPlural` | Custom pluralization function |
+| `messageCompiler` | `MessageCompilerFunc` | ❌ | - | Custom function for compiling messages (ICU MessageFormat support) |
 | `missingWarn` | `boolean` | ❌ | `false` | Show console warnings for missing translations |
 | `missingHandler` | `(locale: string, key: string, routeName: string) => void` | ❌ | - | Custom handler for missing translations |
 

--- a/docs/integrations/vue-package.md
+++ b/docs/integrations/vue-package.md
@@ -423,6 +423,7 @@ Creates and installs the i18n plugin for your Vue application.
 | `fallbackLocale` | `string` | ❌ | Same as `locale` | Fallback locale when translation is missing |
 | `messages` | `Record<string, Translations>` | ❌ | `{}` | Initial translation messages |
 | `plural` | `PluralFunc` | ❌ | `defaultPlural` | Custom pluralization function |
+| `messageCompiler` | `MessageCompilerFunc` | ❌ | - | Custom function for compiling messages (ICU MessageFormat support) |
 | `missingWarn` | `boolean` | ❌ | `false` | Show console warnings for missing translations |
 | `missingHandler` | `(locale: string, key: string, routeName: string) => void` | ❌ | - | Custom handler for missing translations |
 | `routingStrategy` | `I18nRoutingStrategy` | ❌ | - | Router adapter for routing features |

--- a/internals.d.mts
+++ b/internals.d.mts
@@ -1,3 +1,7 @@
 declare module '#build/i18n.plural.mjs' {
-  export function plural(key: string, count: number, params: Params, locale: string, getter: Getter): string | null
+  export function plural(key: string, count: number, params: Record<string, string | number | boolean>, locale: string, getter: (key: string | string[], params?: Record<string, string | number | boolean>, defaultValue?: string) => unknown): string | null
+}
+
+declare module '#build/i18n.message-compiler.mjs' {
+  export const messageCompiler: ((message: string, locale: string, key: string) => ((params?: Record<string, string | number | boolean>) => string)) | undefined
 }

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@i18n-micro/astro",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",

--- a/packages/astro/src/client/core.ts
+++ b/packages/astro/src/client/core.ts
@@ -20,6 +20,13 @@ export interface I18nState {
 // Simple cache for compiled messages (per-island instance)
 const compiledCache = new Map<string, (params?: Params) => string>()
 
+/**
+ * Clear compiled message cache (useful for testing)
+ */
+export function clearCompiledCache(): void {
+  compiledCache.clear()
+}
+
 // Вспомогательная функция для поиска перевода в объекте Translations
 // Returns the value as-is, including objects (for nested translations)
 function findTranslation<T = unknown>(translations: Translations | null, key: string): T | null {
@@ -92,7 +99,7 @@ export function translate(
   if (typeof value === 'string') {
     if (state.messageCompiler) {
       try {
-        const cacheKey = `${state.locale}:${route}:${key}:${value.length}:${value.slice(0, 50)}`
+        const cacheKey = `${state.locale}:${route}:${key}:${value}`
         let compiledFn = compiledCache.get(cacheKey)
         if (!compiledFn) {
           compiledFn = state.messageCompiler(value, state.locale, key)

--- a/packages/astro/src/client/core.ts
+++ b/packages/astro/src/client/core.ts
@@ -1,4 +1,4 @@
-import type { Translations, Params } from '@i18n-micro/types'
+import type { Translations, Params, MessageCompilerFunc } from '@i18n-micro/types'
 import { interpolate } from '@i18n-micro/core'
 
 /**
@@ -9,7 +9,16 @@ export interface I18nState {
   fallbackLocale: string
   translations: Record<string, Translations> // routeName -> translations
   currentRoute: string
+  /**
+   * Optional message compiler for ICU MessageFormat support.
+   * NOTE: For Astro islands, messageCompiler needs to be passed via props
+   * because islands are isolated and don't have access to build-time config.
+   */
+  messageCompiler?: MessageCompilerFunc
 }
+
+// Simple cache for compiled messages (per-island instance)
+const compiledCache = new Map<string, (params?: Params) => string>()
 
 // Вспомогательная функция для поиска перевода в объекте Translations
 // Returns the value as-is, including objects (for nested translations)
@@ -79,9 +88,34 @@ export function translate(
     value = defaultValue === undefined ? key : (defaultValue || key)
   }
 
-  // 4. Интерполяция параметров (только для строк)
-  if (typeof value === 'string' && params) {
-    return interpolate(value, params)
+  // 4. Компиляция/Интерполяция параметров (только для строк)
+  if (typeof value === 'string') {
+    if (state.messageCompiler) {
+      try {
+        const cacheKey = `${state.locale}:${route}:${key}:${value.length}:${value.slice(0, 50)}`
+        let compiledFn = compiledCache.get(cacheKey)
+        if (!compiledFn) {
+          compiledFn = state.messageCompiler(value, state.locale, key)
+          compiledCache.set(cacheKey, compiledFn)
+        }
+        return compiledFn(params ?? {})
+      }
+      catch (err: unknown) {
+        // В режиме разработки выводим предупреждение с деталями
+        if (process.env.NODE_ENV !== 'production') {
+          console.warn(`[i18n] Error compiling message for key '${key}' in Astro island. Falling back to simple interpolation.`, {
+            locale: state.locale,
+            key,
+            message: value,
+            error: err,
+          })
+        }
+        // Откат к простой интерполяции в случае ошибки
+        return params ? interpolate(value, params) : value
+      }
+    }
+
+    return params ? interpolate(value, params) : value
   }
 
   // 5. Возвращаем value как есть (может быть string, number, boolean, object, или null)

--- a/packages/astro/src/composer.ts
+++ b/packages/astro/src/composer.ts
@@ -5,6 +5,7 @@ import {
 import type {
   Translations,
   PluralFunc,
+  MessageCompilerFunc,
 } from '@i18n-micro/types'
 
 export interface AstroI18nOptions {
@@ -12,6 +13,10 @@ export interface AstroI18nOptions {
   fallbackLocale?: string
   messages?: Record<string, Translations>
   plural?: PluralFunc
+  /**
+   * Custom function for compiling messages, enabling ICU MessageFormat or other advanced formatting libraries.
+   */
+  messageCompiler?: MessageCompilerFunc
   missingWarn?: boolean
   missingHandler?: (locale: string, key: string, routeName: string) => void
   // NEW: Allow passing existing cache
@@ -43,6 +48,7 @@ export class AstroI18n extends BaseI18n {
     super({
       cache,
       plural: options.plural,
+      messageCompiler: options.messageCompiler,
       missingWarn: options.missingWarn,
       missingHandler: options.missingHandler,
     })
@@ -174,6 +180,8 @@ export class AstroI18n extends BaseI18n {
   // Методы для добавления переводов
   public addTranslations(locale: string, translations: Translations, merge: boolean = true): void {
     super.loadTranslationsCore(locale, translations, merge)
+    // Clear compiled message cache when translations are updated
+    this.clearCompiledCache()
   }
 
   public addRouteTranslations(
@@ -183,6 +191,8 @@ export class AstroI18n extends BaseI18n {
     merge: boolean = true,
   ): void {
     super.loadRouteTranslationsCore(locale, routeName, translations, merge)
+    // Clear compiled message cache when translations are updated
+    this.clearCompiledCache()
   }
 
   public mergeTranslations(locale: string, routeName: string, translations: Translations): void {

--- a/packages/astro/tests/client-core.test.ts
+++ b/packages/astro/tests/client-core.test.ts
@@ -1,0 +1,182 @@
+import { describe, test, expect, jest, beforeEach } from '@jest/globals'
+import { translate, clearCompiledCache, type I18nState } from '../src/client/core'
+import type { MessageCompilerFunc } from '@i18n-micro/types'
+
+// Clear compiled cache before each test to ensure isolation
+beforeEach(() => {
+  clearCompiledCache()
+})
+
+describe('translate (client/core)', () => {
+  describe('messageCompiler', () => {
+    test('should use messageCompiler when provided', () => {
+      const compiler = jest.fn<MessageCompilerFunc>((msg: string) => () => msg.toUpperCase())
+      const state: I18nState = {
+        locale: 'en',
+        fallbackLocale: 'en',
+        currentRoute: 'general',
+        messageCompiler: compiler,
+        translations: {
+          general: {
+            greeting: 'hello world',
+          },
+        },
+      }
+
+      const result = translate(state, 'greeting')
+      expect(result).toBe('HELLO WORLD')
+      expect(compiler).toHaveBeenCalledWith('hello world', 'en', 'greeting')
+    })
+
+    test('should cache compiled messages', () => {
+      const compiler = jest.fn<MessageCompilerFunc>((msg: string) => () => msg.toUpperCase())
+      const state: I18nState = {
+        locale: 'en',
+        fallbackLocale: 'en',
+        currentRoute: 'general',
+        messageCompiler: compiler,
+        translations: {
+          general: {
+            greeting: 'hello',
+          },
+        },
+      }
+
+      translate(state, 'greeting')
+      translate(state, 'greeting')
+      translate(state, 'greeting')
+
+      // Compiler should be called only once due to caching
+      expect(compiler).toHaveBeenCalledTimes(1)
+    })
+
+    test('should use different cache keys for different messages', () => {
+      const compiler = jest.fn<MessageCompilerFunc>((msg: string) => () => msg.toUpperCase())
+      const state: I18nState = {
+        locale: 'en',
+        fallbackLocale: 'en',
+        currentRoute: 'general',
+        messageCompiler: compiler,
+        translations: {
+          general: {
+            greeting: 'hello',
+            farewell: 'goodbye',
+          },
+        },
+      }
+
+      translate(state, 'greeting')
+      translate(state, 'farewell')
+
+      // Compiler should be called twice (different messages)
+      expect(compiler).toHaveBeenCalledTimes(2)
+    })
+
+    test('should use different cache keys for different locales', () => {
+      const compiler = jest.fn<MessageCompilerFunc>((msg: string, locale: string) => () => `[${locale}]${msg}`)
+      const stateEn: I18nState = {
+        locale: 'en',
+        fallbackLocale: 'en',
+        currentRoute: 'general',
+        messageCompiler: compiler,
+        translations: {
+          general: {
+            greeting: 'hello',
+          },
+        },
+      }
+      const stateDe: I18nState = {
+        locale: 'de',
+        fallbackLocale: 'de',
+        currentRoute: 'general',
+        messageCompiler: compiler,
+        translations: {
+          general: {
+            greeting: 'hello',
+          },
+        },
+      }
+
+      translate(stateEn, 'greeting')
+      translate(stateDe, 'greeting')
+
+      // Compiler should be called twice (different locales)
+      expect(compiler).toHaveBeenCalledTimes(2)
+      expect(compiler).toHaveBeenCalledWith('hello', 'en', 'greeting')
+      expect(compiler).toHaveBeenCalledWith('hello', 'de', 'greeting')
+    })
+
+    test('should use different cache keys for different routes', () => {
+      const compiler = jest.fn<MessageCompilerFunc>((msg: string) => () => msg.toUpperCase())
+      const state: I18nState = {
+        locale: 'en',
+        fallbackLocale: 'en',
+        currentRoute: 'home',
+        messageCompiler: compiler,
+        translations: {
+          general: {
+            title: 'General Title',
+          },
+          home: {
+            title: 'Home Title',
+          },
+        },
+      }
+
+      translate(state, 'title') // Uses home route
+      translate(state, 'title', undefined, undefined, 'general') // Uses general route
+
+      // Compiler should be called twice (different routes)
+      expect(compiler).toHaveBeenCalledTimes(2)
+    })
+
+    test('should fallback to interpolation when messageCompiler throws', () => {
+      const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+      const compiler = jest.fn<MessageCompilerFunc>(() => {
+        throw new Error('Compiler error')
+      })
+      const state: I18nState = {
+        locale: 'en',
+        fallbackLocale: 'en',
+        currentRoute: 'general',
+        messageCompiler: compiler,
+        translations: {
+          general: {
+            greeting: 'Hello, {name}!',
+          },
+        },
+      }
+
+      const result = translate(state, 'greeting', { name: 'John' })
+      expect(result).toBe('Hello, John!')
+      expect(consoleWarnSpy).toHaveBeenCalled()
+
+      consoleWarnSpy.mockRestore()
+    })
+
+    test('should use full content in cache key (not truncated)', () => {
+      const compiler = jest.fn<MessageCompilerFunc>((msg: string) => () => msg)
+      const longMessage = 'a'.repeat(100) + 'b'.repeat(100)
+      const state: I18nState = {
+        locale: 'en',
+        fallbackLocale: 'en',
+        currentRoute: 'general',
+        messageCompiler: compiler,
+        translations: {
+          general: {
+            long: longMessage,
+          },
+        },
+      }
+
+      translate(state, 'long')
+      // Change message after first 50 chars but keep same length
+      const modifiedMessage = 'a'.repeat(50) + 'X' + 'a'.repeat(49) + 'b'.repeat(100)
+      state.translations.general.long = modifiedMessage
+      translate(state, 'long')
+
+      // Compiler should be called twice because full content is different
+      expect(compiler).toHaveBeenCalledTimes(2)
+    })
+  })
+})

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@i18n-micro/core",
-  "version": "1.0.28",
+  "version": "1.0.29",
   "description": "",
   "repository": "s00d/nuxt-i18n-micro",
   "license": "MIT",

--- a/packages/core/src/helpers.ts
+++ b/packages/core/src/helpers.ts
@@ -1,4 +1,31 @@
-import type { Params, Strategies, PluralFunc, Getter, TranslationKey } from '@i18n-micro/types'
+import type { Params, Strategies, PluralFunc, Getter, TranslationKey, MessageCompilerFunc } from '@i18n-micro/types'
+
+/**
+ * Cache for compiled messages
+ * Key format: "locale:route:key:contentLength:contentPrefix"
+ */
+export type CompiledMessageCache = Map<string, (params?: Params) => string>
+
+/**
+ * Generate cache key for compiled message
+ * Includes content info to invalidate when translation changes
+ */
+export function getCompiledCacheKey(
+  locale: string,
+  route: string,
+  key: string,
+  content: string,
+): string {
+  // Use content length + first 50 chars as hash to detect changes
+  return `${locale}:${route}:${key}:${content.length}:${content.slice(0, 50)}`
+}
+
+/**
+ * Create a new compiled message cache
+ */
+export function createCompiledCache(): CompiledMessageCache {
+  return new Map()
+}
 
 export function interpolate(template: string, params: Params): string {
   let result = template
@@ -50,4 +77,59 @@ export const defaultPlural: PluralFunc = (key: TranslationKey, count: number, pa
   const selectedForm = count < forms.length ? forms[count] : forms[forms.length - 1]
   if (!selectedForm) return null
   return selectedForm.trim().replace('{count}', count.toString())
+}
+
+/**
+ * Compile message or fallback to simple interpolation
+ * Centralized function for all adapters
+ *
+ * @param value - The translation string to compile/interpolate
+ * @param locale - Current locale code
+ * @param route - Current route name
+ * @param key - Translation key
+ * @param params - Parameters for interpolation
+ * @param messageCompiler - Optional custom message compiler function
+ * @param cache - Optional cache for compiled messages
+ * @returns Compiled/interpolated string
+ */
+export function compileOrInterpolate(
+  value: string,
+  locale: string,
+  route: string,
+  key: string,
+  params: Params | undefined,
+  messageCompiler: MessageCompilerFunc | undefined,
+  cache: CompiledMessageCache | undefined,
+): string {
+  // Если messageCompiler не задан, используем простую интерполяцию
+  if (!messageCompiler) {
+    return params ? interpolate(value, params) : value
+  }
+
+  try {
+    const cacheKey = getCompiledCacheKey(locale, route, key, value)
+    let compiledFn = cache?.get(cacheKey)
+
+    if (!compiledFn) {
+      // Оборачиваем компиляцию в try/catch
+      compiledFn = messageCompiler(value, locale, key)
+      cache?.set(cacheKey, compiledFn)
+    }
+
+    // Оборачиваем выполнение скомпилированной функции в try/catch
+    return compiledFn(params ?? {})
+  }
+  catch (err: unknown) {
+    // В режиме разработки выводим предупреждение с деталями
+    if (process.env.NODE_ENV !== 'production') {
+      console.warn(`[i18n] Error compiling message for key '${key}'. Falling back to simple interpolation.`, {
+        locale,
+        key,
+        message: value,
+        error: err,
+      })
+    }
+    // Откат к простой интерполяции в случае ошибки
+    return params ? interpolate(value, params) : value
+  }
 }

--- a/packages/core/src/helpers.ts
+++ b/packages/core/src/helpers.ts
@@ -16,8 +16,8 @@ export function getCompiledCacheKey(
   key: string,
   content: string,
 ): string {
-  // Use content length + first 50 chars as hash to detect changes
-  return `${locale}:${route}:${key}:${content.length}:${content.slice(0, 50)}`
+  // Use full content to detect changes accurately
+  return `${locale}:${route}:${key}:${content}`
 }
 
 /**

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,7 +1,19 @@
 import { useTranslationHelper, type TranslationCache } from './translation'
 import { RouteService } from './route-service'
 import { FormatService } from './format-service'
-import { interpolate, withPrefixStrategy, isNoPrefixStrategy, isPrefixStrategy, isPrefixExceptDefaultStrategy, isPrefixAndDefaultStrategy, defaultPlural } from './helpers'
+import {
+  interpolate,
+  withPrefixStrategy,
+  isNoPrefixStrategy,
+  isPrefixStrategy,
+  isPrefixExceptDefaultStrategy,
+  isPrefixAndDefaultStrategy,
+  defaultPlural,
+  compileOrInterpolate,
+  createCompiledCache,
+  getCompiledCacheKey,
+  type CompiledMessageCache,
+} from './helpers'
 import { BaseI18n, type BaseI18nOptions } from './base'
 
 export {
@@ -13,9 +25,14 @@ export {
   isPrefixExceptDefaultStrategy,
   isPrefixAndDefaultStrategy,
   defaultPlural,
+  // Message compiler utilities
+  compileOrInterpolate,
+  createCompiledCache,
+  getCompiledCacheKey,
   RouteService,
   FormatService,
   BaseI18n,
   type TranslationCache,
   type BaseI18nOptions,
+  type CompiledMessageCache,
 }

--- a/packages/core/tests/helpers.test.ts
+++ b/packages/core/tests/helpers.test.ts
@@ -5,7 +5,11 @@ import {
   isPrefixStrategy,
   isPrefixExceptDefaultStrategy,
   isPrefixAndDefaultStrategy,
+  compileOrInterpolate,
+  createCompiledCache,
+  getCompiledCacheKey,
 } from '../src/helpers'
+import type { MessageCompilerFunc } from '@i18n-micro/types'
 
 describe('Helpers', () => {
   describe('interpolate', () => {
@@ -98,6 +102,142 @@ describe('Helpers', () => {
       expect(isPrefixAndDefaultStrategy('no_prefix')).toBe(false)
       expect(isPrefixAndDefaultStrategy('prefix')).toBe(false)
       expect(isPrefixAndDefaultStrategy('prefix_except_default')).toBe(false)
+    })
+  })
+
+  describe('getCompiledCacheKey', () => {
+    test('should include all components', () => {
+      const key = getCompiledCacheKey('en', 'about', 'title', 'Hello World')
+      expect(key).toBe('en:about:title:11:Hello World')
+    })
+
+    test('should truncate long content', () => {
+      const longContent = 'a'.repeat(100)
+      const key = getCompiledCacheKey('en', 'page', 'key', longContent)
+      expect(key).toBe(`en:page:key:100:${'a'.repeat(50)}`)
+    })
+
+    test('should handle empty content', () => {
+      const key = getCompiledCacheKey('en', 'page', 'key', '')
+      expect(key).toBe('en:page:key:0:')
+    })
+  })
+
+  describe('createCompiledCache', () => {
+    test('should create an empty Map', () => {
+      const cache = createCompiledCache()
+      expect(cache).toBeInstanceOf(Map)
+      expect(cache.size).toBe(0)
+    })
+  })
+
+  describe('compileOrInterpolate', () => {
+    test('should use interpolate when no messageCompiler', () => {
+      const result = compileOrInterpolate(
+        'Hello, {name}!',
+        'en',
+        'general',
+        'greeting',
+        { name: 'World' },
+        undefined,
+        undefined,
+      )
+      expect(result).toBe('Hello, World!')
+    })
+
+    test('should return value as-is when no params and no compiler', () => {
+      const result = compileOrInterpolate(
+        'Hello!',
+        'en',
+        'general',
+        'greeting',
+        undefined,
+        undefined,
+        undefined,
+      )
+      expect(result).toBe('Hello!')
+    })
+
+    test('should use messageCompiler when provided', () => {
+      const compiler: MessageCompilerFunc = msg => () => msg.toUpperCase()
+      const cache = createCompiledCache()
+
+      const result = compileOrInterpolate(
+        'hello',
+        'en',
+        'general',
+        'greeting',
+        undefined,
+        compiler,
+        cache,
+      )
+      expect(result).toBe('HELLO')
+    })
+
+    test('should cache compiled messages', () => {
+      const compiler = jest.fn<(params?: Record<string, string | number | boolean>) => string, [string, string, string]>(
+        msg => () => msg.toUpperCase(),
+      )
+      const cache = createCompiledCache()
+
+      compileOrInterpolate('hello', 'en', 'general', 'key', {}, compiler, cache)
+      compileOrInterpolate('hello', 'en', 'general', 'key', {}, compiler, cache)
+
+      expect(compiler).toHaveBeenCalledTimes(1)
+    })
+
+    test('should recompile when content changes', () => {
+      const compiler = jest.fn<(params?: Record<string, string | number | boolean>) => string, [string, string, string]>(
+        msg => () => msg.toUpperCase(),
+      )
+      const cache = createCompiledCache()
+
+      compileOrInterpolate('hello', 'en', 'general', 'key', {}, compiler, cache)
+      compileOrInterpolate('hi there', 'en', 'general', 'key', {}, compiler, cache)
+
+      expect(compiler).toHaveBeenCalledTimes(2)
+    })
+
+    test('should pass params to compiled function', () => {
+      const compiler: MessageCompilerFunc = msg => (params) => {
+        return msg.replace(/\{(\w+)\}/g, (_, k) => String(params?.[k] ?? ''))
+      }
+      const cache = createCompiledCache()
+
+      const result = compileOrInterpolate(
+        'Hello, {name}!',
+        'en',
+        'general',
+        'greeting',
+        { name: 'World' },
+        compiler,
+        cache,
+      )
+      expect(result).toBe('Hello, World!')
+    })
+
+    test('should use different cache keys for different locales', () => {
+      const compiler = jest.fn<(params?: Record<string, string | number | boolean>) => string, [string, string, string]>(
+        (_msg, locale) => () => `[${locale}]`,
+      )
+      const cache = createCompiledCache()
+
+      compileOrInterpolate('hello', 'en', 'general', 'key', {}, compiler, cache)
+      compileOrInterpolate('hello', 'de', 'general', 'key', {}, compiler, cache)
+
+      expect(compiler).toHaveBeenCalledTimes(2)
+    })
+
+    test('should use different cache keys for different routes', () => {
+      const compiler = jest.fn<(params?: Record<string, string | number | boolean>) => string, [string, string, string]>(
+        msg => () => msg,
+      )
+      const cache = createCompiledCache()
+
+      compileOrInterpolate('hello', 'en', 'page1', 'key', {}, compiler, cache)
+      compileOrInterpolate('hello', 'en', 'page2', 'key', {}, compiler, cache)
+
+      expect(compiler).toHaveBeenCalledTimes(2)
     })
   })
 })

--- a/packages/core/tests/helpers.test.ts
+++ b/packages/core/tests/helpers.test.ts
@@ -106,20 +106,33 @@ describe('Helpers', () => {
   })
 
   describe('getCompiledCacheKey', () => {
-    test('should include all components', () => {
+    test('should include all components with full content', () => {
       const key = getCompiledCacheKey('en', 'about', 'title', 'Hello World')
-      expect(key).toBe('en:about:title:11:Hello World')
+      expect(key).toBe('en:about:title:Hello World')
     })
 
-    test('should truncate long content', () => {
-      const longContent = 'a'.repeat(100)
+    test('should use full content (not truncated)', () => {
+      const longContent = 'a'.repeat(100) + 'b'.repeat(100)
       const key = getCompiledCacheKey('en', 'page', 'key', longContent)
-      expect(key).toBe(`en:page:key:100:${'a'.repeat(50)}`)
+      expect(key).toBe(`en:page:key:${longContent}`)
+      // Verify it includes the full content, not just first 50 chars
+      expect(key).toContain('b'.repeat(100))
     })
 
     test('should handle empty content', () => {
       const key = getCompiledCacheKey('en', 'page', 'key', '')
-      expect(key).toBe('en:page:key:0:')
+      expect(key).toBe('en:page:key:')
+    })
+
+    test('should generate different keys for messages with same prefix but different content', () => {
+      const msg1 = 'a'.repeat(50) + 'b'.repeat(50)
+      const msg2 = 'a'.repeat(50) + 'c'.repeat(50)
+      const key1 = getCompiledCacheKey('en', 'page', 'key', msg1)
+      const key2 = getCompiledCacheKey('en', 'page', 'key', msg2)
+      expect(key1).not.toBe(key2)
+      // Both have same length and same first 50 chars, but different keys
+      expect(msg1.length).toBe(msg2.length)
+      expect(msg1.slice(0, 50)).toBe(msg2.slice(0, 50))
     })
   })
 

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@i18n-micro/node",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",

--- a/packages/node/src/i18n.ts
+++ b/packages/node/src/i18n.ts
@@ -143,6 +143,8 @@ export class I18n extends BaseI18n {
 
   public addTranslations(locale: string, translations: Translations, merge: boolean = true): void {
     super.loadTranslationsCore(locale, translations, merge)
+    // Clear compiled message cache when translations are updated
+    this.clearCompiledCache()
   }
 
   public addRouteTranslations(
@@ -152,6 +154,8 @@ export class I18n extends BaseI18n {
     merge: boolean = true,
   ): void {
     super.loadRouteTranslationsCore(locale, routeName, translations, merge)
+    // Clear compiled message cache when translations are updated
+    this.clearCompiledCache()
   }
 
   public hasTranslation(key: TranslationKey): boolean {

--- a/packages/node/src/i18n.ts
+++ b/packages/node/src/i18n.ts
@@ -6,6 +6,7 @@ import type {
   Translations,
   PluralFunc,
   TranslationKey,
+  MessageCompilerFunc,
 } from '@i18n-micro/types'
 // Импортируем нашу общую логику загрузки
 import { loadTranslations } from './loader'
@@ -15,6 +16,10 @@ export interface I18nOptions {
   fallbackLocale?: string
   translationDir?: string
   plural?: PluralFunc
+  /**
+   * Custom function for compiling messages, enabling ICU MessageFormat or other advanced formatting libraries.
+   */
+  messageCompiler?: MessageCompilerFunc
   missingWarn?: boolean
   missingHandler?: (locale: string, key: string, routeName: string) => void
   disablePageLocales?: boolean
@@ -60,6 +65,7 @@ export class I18n extends BaseI18n {
     super({
       cache,
       plural: options.plural,
+      messageCompiler: options.messageCompiler,
       missingWarn: options.missingWarn,
       missingHandler: options.missingHandler,
     })

--- a/packages/node/tests/i18n.test.ts
+++ b/packages/node/tests/i18n.test.ts
@@ -1,5 +1,6 @@
 import { createI18n, I18n } from '../src'
 import { join } from 'node:path'
+import type { MessageCompilerFunc } from '@i18n-micro/types'
 
 describe('I18n (Simple API)', () => {
   const translations = {
@@ -209,6 +210,97 @@ describe('I18n (Simple API)', () => {
 
       // Reload should clear and attempt to reload (even if directory doesn't exist)
       await expect(i18n.reload()).resolves.not.toThrow()
+    })
+  })
+
+  describe('messageCompiler', () => {
+    test('should use messageCompiler when provided', () => {
+      const compiler = jest.fn<(params?: Record<string, string | number | boolean>) => string, [string, string, string]>(
+        (msg: string) => () => msg.toUpperCase(),
+      ) as MessageCompilerFunc
+      const i18n = createI18n({
+        locale: 'en',
+        messageCompiler: compiler,
+      })
+      i18n.addTranslations('en', translations.en)
+
+      const result = i18n.t('welcome')
+      expect(result).toBe('WELCOME')
+      expect(compiler).toHaveBeenCalledWith('Welcome', 'en', 'welcome')
+    })
+
+    test('should cache compiled messages', () => {
+      const compiler = jest.fn<(params?: Record<string, string | number | boolean>) => string, [string, string, string]>(
+        (msg: string) => () => msg.toUpperCase(),
+      ) as MessageCompilerFunc
+      const i18n = createI18n({
+        locale: 'en',
+        messageCompiler: compiler,
+      })
+      i18n.addTranslations('en', translations.en)
+
+      i18n.t('welcome')
+      i18n.t('welcome')
+      i18n.t('welcome')
+
+      // Compiler should be called only once due to caching
+      expect(compiler).toHaveBeenCalledTimes(1)
+    })
+
+    test('should recompile when message changes', () => {
+      const compiler = jest.fn<(params?: Record<string, string | number | boolean>) => string, [string, string, string]>(
+        (msg: string) => () => msg.toUpperCase(),
+      ) as MessageCompilerFunc
+      const i18n = createI18n({
+        locale: 'en',
+        messageCompiler: compiler,
+      })
+      i18n.addTranslations('en', { greeting: 'hello' })
+
+      i18n.t('greeting')
+      i18n.addTranslations('en', { greeting: 'hi there' }, false)
+      i18n.t('greeting')
+
+      // Compiler should be called twice (different messages)
+      expect(compiler).toHaveBeenCalledTimes(2)
+    })
+
+    test('should use correct locale when falling back to fallbackLocale', () => {
+      const compiler = jest.fn<(params?: Record<string, string | number | boolean>) => string, [string, string, string]>(
+        (msg: string, locale: string) => () => `[${locale}]${msg}`,
+      ) as MessageCompilerFunc
+      const i18n = createI18n({
+        locale: 'de',
+        fallbackLocale: 'en',
+        messageCompiler: compiler,
+      })
+      i18n.addTranslations('en', { greeting: 'Hello' })
+      i18n.addTranslations('de', {})
+
+      const result = i18n.t('greeting')
+      // Should use fallback locale 'en' for compilation
+      expect(result).toBe('[en]Hello')
+      expect(compiler).toHaveBeenCalledWith('Hello', 'en', 'greeting')
+    })
+
+    test('should fallback to interpolation when messageCompiler throws', () => {
+      const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+      const compiler = jest.fn<(params?: Record<string, string | number | boolean>) => string, [string, string, string]>(
+        () => {
+          throw new Error('Compiler error')
+        },
+      ) as MessageCompilerFunc
+      const i18n = createI18n({
+        locale: 'en',
+        messageCompiler: compiler,
+      })
+      i18n.addTranslations('en', translations.en)
+
+      const result = i18n.t('greeting', { name: 'John' })
+      expect(result).toBe('Hello, John!')
+      expect(consoleWarnSpy).toHaveBeenCalled()
+
+      consoleWarnSpy.mockRestore()
     })
   })
 })

--- a/packages/preact/package.json
+++ b/packages/preact/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@i18n-micro/preact",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",

--- a/packages/preact/src/i18n.ts
+++ b/packages/preact/src/i18n.ts
@@ -5,6 +5,7 @@ import {
 import type {
   Translations,
   PluralFunc,
+  MessageCompilerFunc,
 } from '@i18n-micro/types'
 
 export interface PreactI18nOptions {
@@ -12,6 +13,10 @@ export interface PreactI18nOptions {
   fallbackLocale?: string
   messages?: Record<string, Translations>
   plural?: PluralFunc
+  /**
+   * Custom function for compiling messages, enabling ICU MessageFormat or other advanced formatting libraries.
+   */
+  messageCompiler?: MessageCompilerFunc
   missingWarn?: boolean
   missingHandler?: (locale: string, key: string, routeName: string) => void
 }
@@ -46,6 +51,7 @@ export class PreactI18n extends BaseI18n {
     super({
       cache,
       plural: options.plural,
+      messageCompiler: options.messageCompiler,
       missingWarn: options.missingWarn,
       missingHandler: options.missingHandler,
     })

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@i18n-micro/react",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/react/src/i18n.ts
+++ b/packages/react/src/i18n.ts
@@ -5,6 +5,7 @@ import {
 import type {
   Translations,
   PluralFunc,
+  MessageCompilerFunc,
 } from '@i18n-micro/types'
 
 export interface ReactI18nOptions {
@@ -12,6 +13,10 @@ export interface ReactI18nOptions {
   fallbackLocale?: string
   messages?: Record<string, Translations>
   plural?: PluralFunc
+  /**
+   * Custom function for compiling messages, enabling ICU MessageFormat or other advanced formatting libraries.
+   */
+  messageCompiler?: MessageCompilerFunc
   missingWarn?: boolean
   missingHandler?: (locale: string, key: string, routeName: string) => void
 }
@@ -45,6 +50,7 @@ export class ReactI18n extends BaseI18n {
     super({
       cache,
       plural: options.plural,
+      messageCompiler: options.messageCompiler,
       missingWarn: options.missingWarn,
       missingHandler: options.missingHandler,
     })

--- a/packages/react/src/i18n.ts
+++ b/packages/react/src/i18n.ts
@@ -140,6 +140,8 @@ export class ReactI18n extends BaseI18n {
   // Translation management (uses protected methods from base class)
   public addTranslations(locale: string, translations: Translations, merge: boolean = true): void {
     super.loadTranslationsCore(locale, translations, merge)
+    // Clear compiled message cache when translations are updated
+    this.clearCompiledCache()
     this.notify()
   }
 
@@ -150,6 +152,8 @@ export class ReactI18n extends BaseI18n {
     merge: boolean = true,
   ): void {
     super.loadRouteTranslationsCore(locale, routeName, translations, merge)
+    // Clear compiled message cache when translations are updated
+    this.clearCompiledCache()
     this.notify()
   }
 

--- a/packages/react/tests/react-i18n.test.ts
+++ b/packages/react/tests/react-i18n.test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect } from '@jest/globals'
 import { createI18n, ReactI18n } from '../src/i18n'
+import type { MessageCompilerFunc } from '@i18n-micro/types'
 
 describe('ReactI18n', () => {
   test('should create i18n instance', () => {
@@ -202,6 +203,93 @@ describe('ReactI18n', () => {
     expect(notified).toBe(true)
 
     unsubscribe()
+  })
+
+  test('should use messageCompiler when provided', () => {
+    const compiler = jest.fn<(params?: Record<string, string | number | boolean>) => string, [string, string, string]>(
+      (msg: string) => () => msg.toUpperCase(),
+    ) as MessageCompilerFunc
+    const i18n = new ReactI18n({
+      locale: 'en',
+      messageCompiler: compiler,
+      messages: {
+        en: {
+          greeting: 'hello world',
+        },
+      },
+    })
+
+    const result = i18n.t('greeting')
+    expect(result).toBe('HELLO WORLD')
+    expect(compiler).toHaveBeenCalledWith('hello world', 'en', 'greeting')
+  })
+
+  test('should cache compiled messages', () => {
+    const compiler = jest.fn<(params?: Record<string, string | number | boolean>) => string, [string, string, string]>(
+      (msg: string) => () => msg.toUpperCase(),
+    ) as MessageCompilerFunc
+    const i18n = new ReactI18n({
+      locale: 'en',
+      messageCompiler: compiler,
+      messages: {
+        en: {
+          greeting: 'hello',
+        },
+      },
+    })
+
+    i18n.t('greeting')
+    i18n.t('greeting')
+    i18n.t('greeting')
+
+    // Compiler should be called only once due to caching
+    expect(compiler).toHaveBeenCalledTimes(1)
+  })
+
+  test('should recompile when message changes', () => {
+    const compiler = jest.fn<(params?: Record<string, string | number | boolean>) => string, [string, string, string]>(
+      (msg: string) => () => msg.toUpperCase(),
+    ) as MessageCompilerFunc
+    const i18n = new ReactI18n({
+      locale: 'en',
+      messageCompiler: compiler,
+      messages: {
+        en: {
+          greeting: 'hello',
+        },
+      },
+    })
+
+    i18n.t('greeting')
+    i18n.addTranslations('en', { greeting: 'hi there' }, false)
+    i18n.t('greeting')
+
+    // Compiler should be called twice (different messages)
+    expect(compiler).toHaveBeenCalledTimes(2)
+  })
+
+  test('should fallback to interpolation when messageCompiler throws', () => {
+    const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+    const compiler = jest.fn<(params?: Record<string, string | number | boolean>) => string, [string, string, string]>(
+      () => {
+        throw new Error('Compiler error')
+      },
+    ) as MessageCompilerFunc
+    const i18n = new ReactI18n({
+      locale: 'en',
+      messageCompiler: compiler,
+      messages: {
+        en: {
+          greeting: 'Hello, {name}!',
+        },
+      },
+    })
+
+    const result = i18n.t('greeting', { name: 'John' })
+    expect(result).toBe('Hello, John!')
+    expect(consoleWarnSpy).toHaveBeenCalled()
+
+    consoleWarnSpy.mockRestore()
   })
 })
 

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@i18n-micro/solid",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",

--- a/packages/solid/src/i18n.ts
+++ b/packages/solid/src/i18n.ts
@@ -154,6 +154,8 @@ export class SolidI18n extends BaseI18n {
     else {
       this.setCacheStore('general', locale, translations)
     }
+    // Clear compiled message cache when translations are updated
+    this.clearCompiledCache()
     this.notifyListeners()
   }
 
@@ -168,6 +170,8 @@ export class SolidI18n extends BaseI18n {
     else {
       this.setCacheStore('route', key, translations)
     }
+    // Clear compiled message cache when translations are updated
+    this.clearCompiledCache()
     this.notifyListeners()
   }
 

--- a/packages/solid/src/i18n.ts
+++ b/packages/solid/src/i18n.ts
@@ -1,13 +1,17 @@
 import { createSignal, type Accessor, type Setter } from 'solid-js'
 import { createStore, type SetStoreFunction } from 'solid-js/store'
 import { BaseI18n, type TranslationCache } from '@i18n-micro/core'
-import type { Translations, PluralFunc } from '@i18n-micro/types'
+import type { Translations, PluralFunc, MessageCompilerFunc } from '@i18n-micro/types'
 
 export interface SolidI18nOptions {
   locale: string
   fallbackLocale?: string
   messages?: Record<string, Translations>
   plural?: PluralFunc
+  /**
+   * Custom function for compiling messages, enabling ICU MessageFormat or other advanced formatting libraries.
+   */
+  messageCompiler?: MessageCompilerFunc
   missingWarn?: boolean
   missingHandler?: (locale: string, key: string, routeName: string) => void
 }
@@ -68,6 +72,7 @@ export class SolidI18n extends BaseI18n {
     super({
       cache: cacheAdapter,
       plural: options.plural,
+      messageCompiler: options.messageCompiler,
       missingWarn: options.missingWarn,
       missingHandler: options.missingHandler,
     })

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@i18n-micro/test-utils",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "",
   "repository": "s00d/nuxt-i18n-micro",
   "license": "MIT",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@i18n-micro/types",
-  "version": "1.0.16",
+  "version": "1.0.17",
   "description": "",
   "repository": "s00d/nuxt-i18n-micro",
   "license": "MIT",

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -52,6 +52,31 @@ export type Params = Record<string, string | number | boolean>
 export type Getter = (key: TranslationKey, params?: Record<string, string | number | boolean>, defaultValue?: string) => unknown
 export type PluralFunc = (key: TranslationKey, count: number, params: Params, locale: string, getter: Getter) => string | null
 
+/**
+ * Message compiler function for custom message formatting (e.g., ICU MessageFormat).
+ * Returns a cached function that accepts params and returns the formatted string.
+ *
+ * @param message - The raw translation message string
+ * @param locale - The current locale code
+ * @param key - The translation key
+ * @returns A function that accepts params and returns the formatted message
+ *
+ * @example
+ * ```typescript
+ * import IntlMessageFormat from 'intl-messageformat'
+ *
+ * const messageCompiler: MessageCompilerFunc = (message, locale, key) => {
+ *   const formatter = new IntlMessageFormat(message, locale)
+ *   return (params) => formatter.format(params) as string
+ * }
+ * ```
+ */
+export type MessageCompilerFunc = (
+  message: string,
+  locale: string,
+  key: string
+) => (params?: Params) => string
+
 export type GlobalLocaleRoutes = Record<string, Record<LocaleCode, string> | false | boolean> | null | undefined
 
 export type Strategies = 'no_prefix' | 'prefix_except_default' | 'prefix' | 'prefix_and_default'
@@ -85,6 +110,21 @@ export interface ModuleOptions {
   includeDefaultLocaleRoute?: boolean
   routesLocaleLinks?: { [key: string]: string }
   plural?: string | PluralFunc
+  /**
+   * Custom function for compiling messages, enabling ICU MessageFormat or other advanced formatting libraries.
+   * When provided, this function will be used instead of the default simple interpolation.
+   *
+   * @example
+   * ```typescript
+   * import IntlMessageFormat from 'intl-messageformat'
+   *
+   * messageCompiler: (message, locale, _key) => {
+   *   const formatter = new IntlMessageFormat(message, locale)
+   *   return (params) => formatter.format(params) as string
+   * }
+   * ```
+   */
+  messageCompiler?: MessageCompilerFunc
   disablePageLocales?: boolean
   fallbackLocale?: string
   localeCookie?: string

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@i18n-micro/vue",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",

--- a/packages/vue/src/composer.ts
+++ b/packages/vue/src/composer.ts
@@ -6,6 +6,7 @@ import {
 import type {
   Translations,
   PluralFunc,
+  MessageCompilerFunc,
 } from '@i18n-micro/types'
 
 export interface VueI18nOptions {
@@ -13,6 +14,10 @@ export interface VueI18nOptions {
   fallbackLocale?: string
   messages?: Record<string, Translations>
   plural?: PluralFunc
+  /**
+   * Custom function for compiling messages, enabling ICU MessageFormat or other advanced formatting libraries.
+   */
+  messageCompiler?: MessageCompilerFunc
   missingWarn?: boolean
   missingHandler?: (locale: string, key: string, routeName: string) => void
 }
@@ -41,6 +46,7 @@ export class VueI18n extends BaseI18n {
     super({
       cache,
       plural: options.plural,
+      messageCompiler: options.messageCompiler,
       missingWarn: options.missingWarn,
       missingHandler: options.missingHandler,
     })

--- a/packages/vue/src/composer.ts
+++ b/packages/vue/src/composer.ts
@@ -120,6 +120,8 @@ export class VueI18n extends BaseI18n {
   // Методы для добавления переводов (реактивно) - uses protected methods from base class
   public addTranslations(locale: string, translations: Translations, merge: boolean = true): void {
     super.loadTranslationsCore(locale, translations, merge)
+    // Clear compiled message cache when translations are updated
+    this.clearCompiledCache()
     // Триггерим реактивность для shallowRef после изменения объекта внутри
     // В Vue пакете cache всегда содержит shallowRef, поэтому используем type assertion
     triggerRef(this.cache.generalLocaleCache as Ref<Record<string, Translations>>)
@@ -133,6 +135,8 @@ export class VueI18n extends BaseI18n {
     merge: boolean = true,
   ): void {
     super.loadRouteTranslationsCore(locale, routeName, translations, merge)
+    // Clear compiled message cache when translations are updated
+    this.clearCompiledCache()
     // Триггерим реактивность для shallowRef после изменения объекта внутри
     triggerRef(this.cache.routeLocaleCache as Ref<Record<string, Translations>>)
     this.notifyListeners()

--- a/src/module.ts
+++ b/src/module.ts
@@ -186,14 +186,14 @@ export default defineNuxtModule<ModuleOptions>({
       getContents: () => `export const plural = ${options.plural!.toString()};`,
     })
 
-    // Generate messageCompiler template if provided
-    if (options.messageCompiler) {
-      addTemplate({
-        filename: 'i18n.message-compiler.mjs',
-        write: true,
-        getContents: () => `export const messageCompiler = ${options.messageCompiler!.toString()};`,
-      })
-    }
+    // Generate messageCompiler template (always create, even if undefined, to avoid import errors)
+    addTemplate({
+      filename: 'i18n.message-compiler.mjs',
+      write: true,
+      getContents: () => options.messageCompiler
+        ? `export const messageCompiler = ${options.messageCompiler.toString()};`
+        : `export const messageCompiler = undefined;`,
+    })
 
     let apiBaseClientHost = process.env.NUXT_I18N_APP_BASE_CLIENT_HOST ?? options.apiBaseClientHost ?? undefined
     if (apiBaseClientHost && apiBaseClientHost.endsWith('/')) {

--- a/src/module.ts
+++ b/src/module.ts
@@ -186,6 +186,15 @@ export default defineNuxtModule<ModuleOptions>({
       getContents: () => `export const plural = ${options.plural!.toString()};`,
     })
 
+    // Generate messageCompiler template if provided
+    if (options.messageCompiler) {
+      addTemplate({
+        filename: 'i18n.message-compiler.mjs',
+        write: true,
+        getContents: () => `export const messageCompiler = ${options.messageCompiler!.toString()};`,
+      })
+    }
+
     let apiBaseClientHost = process.env.NUXT_I18N_APP_BASE_CLIENT_HOST ?? options.apiBaseClientHost ?? undefined
     if (apiBaseClientHost && apiBaseClientHost.endsWith('/')) {
       apiBaseClientHost = apiBaseClientHost.slice(0, -1)

--- a/src/runtime/plugins/01.plugin.ts
+++ b/src/runtime/plugins/01.plugin.ts
@@ -6,7 +6,7 @@ import type {
   RouteLocationNamedRaw,
 } from 'vue-router'
 import { useTranslationHelper, isNoPrefixStrategy, RouteService, FormatService, compileOrInterpolate, createCompiledCache, type TranslationCache } from '@i18n-micro/core'
-import type { ModuleOptionsExtend, Locale, I18nRouteParams, Params, Translations, CleanTranslation, MissingHandler, MessageCompilerFunc, Getter, TranslationKey } from '@i18n-micro/types'
+import type { ModuleOptionsExtend, Locale, I18nRouteParams, Params, Translations, CleanTranslation, MissingHandler, MessageCompilerFunc } from '@i18n-micro/types'
 import { useRouter, useCookie, navigateTo, defineNuxtPlugin, useRuntimeConfig, createError } from '#imports'
 import { unref } from 'vue'
 import { useState } from '#app'
@@ -38,11 +38,11 @@ async function loadMessageCompiler(): Promise<MessageCompilerFunc | undefined> {
           (err as NodeJS.ErrnoException).code === 'MODULE_NOT_FOUND'
           || (err as NodeJS.ErrnoException).code === 'ERR_PACKAGE_IMPORT_NOT_DEFINED'
         ))
-          || ('message' in err && (
-            (err as Error).message?.includes('Cannot find module')
-            || (err as Error).message?.includes('Package import specifier')
-            || (err as Error).message?.includes('is not defined')
-          )))
+        || ('message' in err && (
+          (err as Error).message?.includes('Cannot find module')
+          || (err as Error).message?.includes('Package import specifier')
+          || (err as Error).message?.includes('is not defined')
+        )))
 
     // Игнорируем только если модуль действительно отсутствует (нормально, если messageCompiler не настроен).
     // Все остальные ошибки (например, синтаксические) выводим в консоль.
@@ -297,7 +297,7 @@ export default defineNuxtPlugin(async (nuxtApp) => {
       const { count, ..._params } = typeof params === 'number' ? { count: params } : params
 
       if (count === undefined) return defaultValue ?? key
-      
+
       // Create a getter wrapper that matches the signature expected by plural function
       // The plural function expects: (key: string | string[], params?: Params, defaultValue?: string) => unknown
       const getter = (translationKey: string | string[], getterParams?: Params, getterDefaultValue?: string): unknown => {
@@ -305,7 +305,7 @@ export default defineNuxtPlugin(async (nuxtApp) => {
         const keyStr = Array.isArray(translationKey) ? translationKey.join('.') : translationKey
         return provideData.t(keyStr, getterParams, getterDefaultValue ?? undefined)
       }
-      
+
       return plural(key, Number.parseInt(count.toString()), _params, currentLocale, getter) as string ?? defaultValue ?? key
     },
     tn: (value: number, options?: Intl.NumberFormatOptions) => {

--- a/src/runtime/plugins/01.plugin.ts
+++ b/src/runtime/plugins/01.plugin.ts
@@ -6,7 +6,7 @@ import type {
   RouteLocationNamedRaw,
 } from 'vue-router'
 import { useTranslationHelper, isNoPrefixStrategy, RouteService, FormatService, compileOrInterpolate, createCompiledCache, type TranslationCache } from '@i18n-micro/core'
-import type { ModuleOptionsExtend, Locale, I18nRouteParams, Params, Translations, CleanTranslation, MissingHandler, MessageCompilerFunc } from '@i18n-micro/types'
+import type { ModuleOptionsExtend, Locale, I18nRouteParams, Params, Translations, CleanTranslation, MissingHandler, MessageCompilerFunc, Getter, TranslationKey } from '@i18n-micro/types'
 import { useRouter, useCookie, navigateTo, defineNuxtPlugin, useRuntimeConfig, createError } from '#imports'
 import { unref } from 'vue'
 import { useState } from '#app'
@@ -29,13 +29,22 @@ async function loadMessageCompiler(): Promise<MessageCompilerFunc | undefined> {
   }
   catch (err: unknown) {
     // Определяем, является ли ошибка ошибкой "модуль не найден"
+    // Это может быть MODULE_NOT_FOUND, ERR_PACKAGE_IMPORT_NOT_DEFINED (для package imports),
+    // или сообщение об ошибке, содержащее информацию о том, что модуль не найден
     const isModuleMissing
       = err
         && typeof err === 'object'
-        && (('code' in err && (err as NodeJS.ErrnoException).code === 'MODULE_NOT_FOUND')
-          || ('message' in err && (err as Error).message?.includes('Cannot find module')))
+        && (('code' in err && (
+          (err as NodeJS.ErrnoException).code === 'MODULE_NOT_FOUND'
+          || (err as NodeJS.ErrnoException).code === 'ERR_PACKAGE_IMPORT_NOT_DEFINED'
+        ))
+          || ('message' in err && (
+            (err as Error).message?.includes('Cannot find module')
+            || (err as Error).message?.includes('Package import specifier')
+            || (err as Error).message?.includes('is not defined')
+          )))
 
-    // Игнорируем только если модуль действительно отсутствует.
+    // Игнорируем только если модуль действительно отсутствует (нормально, если messageCompiler не настроен).
     // Все остальные ошибки (например, синтаксические) выводим в консоль.
     if (!isModuleMissing) {
       console.error('[i18n] Failed to load message compiler. Check for errors in your messageCompiler function in nuxt.config:', err)
@@ -288,7 +297,16 @@ export default defineNuxtPlugin(async (nuxtApp) => {
       const { count, ..._params } = typeof params === 'number' ? { count: params } : params
 
       if (count === undefined) return defaultValue ?? key
-      return plural(key, Number.parseInt(count.toString()), _params, currentLocale, provideData.t) as string ?? defaultValue ?? key
+      
+      // Create a getter wrapper that matches the signature expected by plural function
+      // The plural function expects: (key: string | string[], params?: Params, defaultValue?: string) => unknown
+      const getter = (translationKey: string | string[], getterParams?: Params, getterDefaultValue?: string): unknown => {
+        // Convert TranslationKey (string | string[]) to string for provideData.t
+        const keyStr = Array.isArray(translationKey) ? translationKey.join('.') : translationKey
+        return provideData.t(keyStr, getterParams, getterDefaultValue ?? undefined)
+      }
+      
+      return plural(key, Number.parseInt(count.toString()), _params, currentLocale, getter) as string ?? defaultValue ?? key
     },
     tn: (value: number, options?: Intl.NumberFormatOptions) => {
       const currentLocale = routeService.getCurrentLocale()

--- a/src/runtime/translation-server-middleware.ts
+++ b/src/runtime/translation-server-middleware.ts
@@ -34,11 +34,11 @@ async function getMessageCompiler(): Promise<MessageCompilerFunc | undefined> {
             (err as NodeJS.ErrnoException).code === 'MODULE_NOT_FOUND'
             || (err as NodeJS.ErrnoException).code === 'ERR_PACKAGE_IMPORT_NOT_DEFINED'
           ))
-            || ('message' in err && (
-              (err as Error).message?.includes('Cannot find module')
-              || (err as Error).message?.includes('Package import specifier')
-              || (err as Error).message?.includes('is not defined')
-            )))
+          || ('message' in err && (
+            (err as Error).message?.includes('Cannot find module')
+            || (err as Error).message?.includes('Package import specifier')
+            || (err as Error).message?.includes('is not defined')
+          )))
 
       // Игнорируем только если модуль действительно отсутствует (нормально, если messageCompiler не настроен).
       // Все остальные ошибки (например, синтаксические) выводим в консоль.

--- a/src/runtime/translation-server-middleware.ts
+++ b/src/runtime/translation-server-middleware.ts
@@ -1,9 +1,38 @@
 import type { H3Event } from 'h3'
-import { interpolate, useTranslationHelper } from '@i18n-micro/core'
+import { useTranslationHelper, compileOrInterpolate, createCompiledCache } from '@i18n-micro/core'
 import type { TranslationCache } from '@i18n-micro/core/dist/translation' // <-- Direct type import
-import type { ModuleOptionsExtend, ModulePrivateOptionsExtend, Params, Translations } from '@i18n-micro/types'
+import type { ModuleOptionsExtend, ModulePrivateOptionsExtend, Params, Translations, MessageCompilerFunc } from '@i18n-micro/types'
 import { detectCurrentLocale } from './utils/locale-detector'
 import { useRuntimeConfig } from '#imports'
+
+// Lazy load messageCompiler (with proper error handling)
+let messageCompiler: MessageCompilerFunc | undefined
+let messageCompilerLoaded = false
+
+async function getMessageCompiler(): Promise<MessageCompilerFunc | undefined> {
+  if (messageCompilerLoaded) return messageCompiler
+  messageCompilerLoaded = true
+  try {
+    const modName = '#build/i18n.message-compiler.mjs'
+    const mod = await import(/* @vite-ignore */ modName)
+    messageCompiler = mod.messageCompiler
+  }
+  catch (err: unknown) {
+    // Определяем, является ли ошибка ошибкой "модуль не найден"
+    const isModuleMissing
+      = err
+        && typeof err === 'object'
+        && (('code' in err && (err as NodeJS.ErrnoException).code === 'MODULE_NOT_FOUND')
+          || ('message' in err && (err as Error).message?.includes('Cannot find module')))
+
+    // Игнорируем только если модуль действительно отсутствует.
+    // Все остальные ошибки (например, синтаксические) выводим в консоль.
+    if (!isModuleMissing) {
+      console.error('[i18n] Failed to load message compiler. Check for errors in your messageCompiler function in nuxt.config:', err)
+    }
+  }
+  return messageCompiler
+}
 
 // Constant for the request context key to avoid typos
 const I18N_CONTEXT_KEY = '__i18n_cache__'
@@ -70,13 +99,38 @@ export const useTranslationServerMiddleware = async (event: H3Event, defaultLoca
     await loadTranslations(locale, translations)
   }
 
+  // Load messageCompiler lazily
+  const compiler = await getMessageCompiler()
+
+  // Get or create compiled message cache for this request
+  // Store in event.context to avoid type issues with serverTranslationCache
+  const compiledCacheContextKey = '__i18n_compiled_cache__'
+  if (!event.context[compiledCacheContextKey]) {
+    event.context[compiledCacheContextKey] = createCompiledCache()
+  }
+  const compiledCache = event.context[compiledCacheContextKey] as ReturnType<typeof createCompiledCache>
+
   function t(key: string, params?: Params, defaultValue?: string): string {
     // getTranslation will also operate on requestScopedCache
     let translation = getTranslation<string>(locale, 'index', key)
     if (!translation) {
       translation = defaultValue || key
     }
-    return typeof translation === 'string' && params ? interpolate(translation, params) : translation
+
+    // Compile/Interpolate (using centralized utility)
+    if (typeof translation === 'string') {
+      return compileOrInterpolate(
+        translation,
+        locale,
+        'index', // routeName for server middleware
+        key,
+        params,
+        compiler,
+        compiledCache,
+      )
+    }
+
+    return translation
   }
 
   return t

--- a/test/basic.spec.ts
+++ b/test/basic.spec.ts
@@ -293,6 +293,24 @@ test.describe('basic', () => {
   })
 
   test('test locale switching on locale-test page', async ({ page }) => {
+    // Calculate expected date (approximately 1 year ago, 13-14 months to ensure >= 1 year)
+    const oneYearAgo = new Date()
+    oneYearAgo.setFullYear(oneYearAgo.getFullYear() - 1)
+    oneYearAgo.setMonth(oneYearAgo.getMonth() - 2) // Subtract 2 more months to ensure >= 1 year
+    oneYearAgo.setDate(1)
+
+    // Calculate expected date formats
+    const expectedDateEn = new Intl.DateTimeFormat('en-US').format(oneYearAgo)
+    const expectedDateDe = new Intl.DateTimeFormat('de-DE').format(oneYearAgo)
+    const expectedDateRu = new Intl.DateTimeFormat('ru-RU').format(oneYearAgo)
+
+    // Calculate expected relative time using the same logic as FormatService
+    const diffSeconds = Math.floor((Date.now() - oneYearAgo.getTime()) / 1000)
+    const diffYears = Math.floor(diffSeconds / 31536000) // 31536000 seconds in a year
+    const expectedRelativeEn = new Intl.RelativeTimeFormat('en-US').format(-diffYears, 'year')
+    const expectedRelativeDe = new Intl.RelativeTimeFormat('de-DE').format(-diffYears, 'year')
+    const expectedRelativeRu = new Intl.RelativeTimeFormat('ru-RU').format(-diffYears, 'year')
+
     // Navigate to the /locale-test route in English
     await page.goto('/locale-test', { waitUntil: 'networkidle' })
 
@@ -306,11 +324,11 @@ test.describe('basic', () => {
     await expect(page.locator('#plural-2')).toHaveText('You have 2 items')
     await expect(page.locator('#plural-3')).toHaveText('You have 3 items')
     await expect(page.locator('#number-tn')).toHaveText('1,234,567.89')
-    await expect(page.locator('#date-td')).toHaveText('12/31/2023')
-    await expect(page.locator('#date-tdr')).toHaveText('1 year ago')
+    await expect(page.locator('#date-td')).toHaveText(expectedDateEn)
+    await expect(page.locator('#date-tdr')).toHaveText(expectedRelativeEn)
     await expect(page.locator('#number-tn-component')).toHaveText('The number is: 1,234,567.89')
-    await expect(page.locator('#date-td-component')).toHaveText('The date is: 12/31/2023')
-    await expect(page.locator('#date-tdr-component')).toHaveText('The relative date is: 1 year ago')
+    await expect(page.locator('#date-td-component')).toHaveText(`The date is: ${expectedDateEn}`)
+    await expect(page.locator('#date-tdr-component')).toHaveText(`The relative date is: ${expectedRelativeEn}`)
     await expect(page.locator('#html-content')).toHaveText('Bold Text with HTML content.')
 
     const linkDe = page.locator('#link-de')
@@ -329,11 +347,11 @@ test.describe('basic', () => {
     await expect(page.locator('#plural-2')).toHaveText('Sie haben 2 Artikel')
     await expect(page.locator('#plural-3')).toHaveText('Sie haben 3 Artikel')
     await expect(page.locator('#number-tn')).toHaveText('1.234.567,89')
-    await expect(page.locator('#date-td')).toHaveText('31.12.2023')
-    await expect(page.locator('#date-tdr')).toHaveText('vor 1 Jahr')
+    await expect(page.locator('#date-td')).toHaveText(expectedDateDe)
+    await expect(page.locator('#date-tdr')).toHaveText(expectedRelativeDe)
     await expect(page.locator('#number-tn-component')).toHaveText('Die Zahl ist: 1.234.567,89')
-    await expect(page.locator('#date-td-component')).toHaveText('Das Datum ist: 31.12.2023')
-    await expect(page.locator('#date-tdr-component')).toHaveText('Das relative Datum ist: vor 1 Jahr')
+    await expect(page.locator('#date-td-component')).toHaveText(`Das Datum ist: ${expectedDateDe}`)
+    await expect(page.locator('#date-tdr-component')).toHaveText(`Das relative Datum ist: ${expectedRelativeDe}`)
     await expect(page.locator('#html-content')).toHaveText('Fetter Text mit HTML-Inhalt.')
 
     const linkRu = page.locator('#link-ru')
@@ -342,7 +360,7 @@ test.describe('basic', () => {
     // Switch to German locale
     await linkRu.click()
 
-    // Verify the URL and content in German
+    // Verify the URL and content in Russian
     await expect(page).toHaveURL('/ru/locale-page-modify-ru')
     await expect(page.locator('h1')).toHaveText('Страница теста языка')
     await expect(page.locator('#content')).toHaveText('Это раздел содержимого.')
@@ -352,11 +370,11 @@ test.describe('basic', () => {
     await expect(page.locator('#plural-2')).toHaveText('У вас 2 предмета')
     await expect(page.locator('#plural-3')).toHaveText('У вас 3 предмета')
     await expect(page.locator('#number-tn')).toHaveText('1 234 567,89')
-    await expect(page.locator('#date-td')).toHaveText('31.12.2023')
-    await expect(page.locator('#date-tdr')).toHaveText('1 год назад')
+    await expect(page.locator('#date-td')).toHaveText(expectedDateRu)
+    await expect(page.locator('#date-tdr')).toHaveText(expectedRelativeRu)
     await expect(page.locator('#number-tn-component')).toHaveText('Число: 1 234 567,89')
-    await expect(page.locator('#date-td-component')).toHaveText('Дата: 31.12.2023')
-    await expect(page.locator('#date-tdr-component')).toHaveText('Относительная дата: 1 год назад')
+    await expect(page.locator('#date-td-component')).toHaveText(`Дата: ${expectedDateRu}`)
+    await expect(page.locator('#date-tdr-component')).toHaveText(`Относительная дата: ${expectedRelativeRu}`)
     await expect(page.locator('#html-content')).toHaveText('Жирный текст с HTML-содержимым.')
   })
 

--- a/test/fixtures/basic/pages/locale-test.vue
+++ b/test/fixtures/basic/pages/locale-test.vue
@@ -46,22 +46,22 @@
     </p>
 
     <div id="date-td">
-      {{ $td('2023-12-31') }}
+      {{ $td(oneYearAgo) }}
     </div>
     <p id="date-td-component">
       <i18n-t
         keypath="page.date"
-        date="2023-12-31"
+        :date="oneYearAgo"
       />
     </p>
 
     <div id="date-tdr">
-      {{ $tdr('2023-12-31') }}
+      {{ $tdr(oneYearAgo) }}
     </div>
     <p id="date-tdr-component">
       <i18n-t
         keypath="page.relativeDate"
-        relative-date="2023-12-31"
+        :relative-date="oneYearAgo"
       />
     </p>
 
@@ -96,9 +96,19 @@
 </template>
 
 <script setup>
+import { computed } from 'vue'
 import { useNuxtApp } from '#imports'
 
 const { $defineI18nRoute, $tn, $td, $tdr } = useNuxtApp()
+
+// Calculate date approximately 1 year ago (13-14 months to ensure it's always >= 1 year)
+const oneYearAgo = computed(() => {
+  const date = new Date()
+  date.setFullYear(date.getFullYear() - 1)
+  date.setMonth(date.getMonth() - 2) // Subtract 2 more months to ensure >= 1 year
+  date.setDate(1)
+  return date.toISOString().split('T')[0]
+})
 
 // Define translations directly on the page
 $defineI18nRoute({


### PR DESCRIPTION
<!-- Thank you for contributing! 🎉 -->

## 📝 Description

<!-- What does this PR do? -->


## 🔗 Related Issue

Closes #
Relates to #

## 🎯 Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance
- [ ] ✅ Tests

## 🧪 Testing

### Environment

- **OS**: 
- **Node**: 
- **Nuxt**: 

### Tested

- [ ] Existing tests pass (`pnpm test`)
- [ ] Added new tests
- [ ] Manual testing
- [ ] Tested in production build

## 📋 Checklist

- [ ] Code follows style guidelines
- [ ] Self-reviewed my code
- [ ] Commented complex code
- [ ] Updated documentation
- [ ] Updated types (if needed)
- [ ] No new warnings/errors
- [ ] Tests pass

## 🖼️ Screenshots (optional)

<details>
<summary>Before / After</summary>

<!-- Screenshots here -->

</details>

## 💡 Notes

<!-- Any additional context for reviewers -->


---

💡 See full guidelines: [Contribution Guide](https://s00d.github.io/nuxt-i18n-micro/guide/contribution)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new messageCompiler option to enable ICU MessageFormat and custom message formatting across all adapters, with caching, lazy loading, and safe fallbacks. Centralizes compile/interpolate logic and updates docs and tests.

- **New Features**
  - Introduced MessageCompilerFunc and i18n.messageCompiler option in Nuxt, Vue, React, Preact, Solid, Node, and Astro.
  - Added compileOrInterpolate utility with per-locale/route compiled cache and automatic invalidation on locale change or translation updates.
  - Implemented lazy loading with error handling in Nuxt plugin and server middleware; falls back to simple interpolation on errors.
  - Updated docs with ICU examples and added unit tests for compiler usage, caching, and invalidation.

<sup>Written for commit be51fd548f0f1010da1e10cb8f3e349f5fd2f357. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

