### PR TITLE
fix: skip internal route rules during localization

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -21,6 +21,7 @@ import type { HookResult, NuxtPage } from '@nuxt/schema'
 import { globby } from 'globby'
 import { setupDevToolsUI } from './devtools'
 import { generateHmrPlugin } from './hmr-plugin'
+import { shouldLocalizeRouteRulePath } from './route-rules'
 import type { PluginsInjections } from './runtime/plugins/01.plugin'
 import { extractDefineI18nRouteData } from './utils'
 
@@ -706,7 +707,7 @@ declare module '#i18n-internal/plural' {
         nitroConfig.routeRules = nitroConfig.routeRules || {}
 
         for (const [originalPath, ruleValue] of Object.entries(routeRules)) {
-          if (originalPath.startsWith('/api')) continue
+          if (!shouldLocalizeRouteRulePath(originalPath)) continue
 
           routeGenerator.locales.forEach((localeObj) => {
             const localeCode = localeObj.code

--- a/src/route-rules.ts
+++ b/src/route-rules.ts
@@ -1,0 +1,10 @@
+export function shouldLocalizeRouteRulePath(originalPath: string): boolean {
+  const routeRulePath = originalPath.trim()
+  if (!routeRulePath) return true
+
+  const path = routeRulePath.startsWith('/') ? routeRulePath : `/${routeRulePath}`
+  if (path.startsWith('/api')) return false
+
+  const firstSegment = path.replace(/^\/+/, '').split('/')[0]
+  return !firstSegment.startsWith('_')
+}

--- a/test/route-rules.test.ts
+++ b/test/route-rules.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from 'vitest'
+import { shouldLocalizeRouteRulePath } from '../src/route-rules'
+
+describe('routeRules localization', () => {
+  test.each(['/', '/about', '/products/**', '/blog/:slug', '/tools/_assets'])('localizes public route rule %s', (routeRulePath) => {
+    expect(shouldLocalizeRouteRulePath(routeRulePath)).toBe(true)
+  })
+
+  test.each([
+    '/api',
+    '/api/users',
+    '/api/**',
+    '/_nuxt/**',
+    '/_locales/**',
+    '/__nuxt_content/**',
+    '/__sitemap__/**',
+  ])('skips internal route rule %s', (routeRulePath) => {
+    expect(shouldLocalizeRouteRulePath(routeRulePath)).toBe(false)
+  })
+})


### PR DESCRIPTION
Fixes #220.

## Summary

- skip route rule localization for internal first-segment paths such as `/_nuxt/**`, `/_locales/**`, `/__nuxt_content/**`, and `/__sitemap__/**`
- preserve the existing `/api` skip behavior
- keep public route rules localizable, including public paths that contain an underscore later in the path
- add a focused regression test for the route rule path classifier

## Tests

- `pnpm --filter @i18n-micro/route-strategy --filter @i18n-micro/test-utils run build`
- `pnpm run dev:prepare`
- `pnpm exec vitest run test/route-rules.test.ts`
- `pnpm exec biome check src/route-rules.ts test/route-rules.test.ts`



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip localizing internal route rules whose first path segment starts with `_`, and continue skipping `/api`. This prevents i18n prefixes on Nuxt internals while still localizing public routes, even if they contain underscores later in the path.

- **Bug Fixes**
  - Apply `shouldLocalizeRouteRulePath` to skip `/_nuxt/**`, `/_locales/**`, `/__nuxt_content/**`, `/__sitemap__/**`, and any path with a leading underscore segment.
  - Preserve existing `/api` exclusion.
  - Keep public routes localizable (e.g., `/tools/_assets`).
  - Add regression tests for the route rule path classifier.

<sup>Written for commit 40c7ce8735f1e0f1d07adab5b15cf9728b4d6886. Summary will update on new commits. <a href="https://cubic.dev/pr/s00d/nuxt-i18n-micro/pull/221?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

