### PR TITLE
test(path-strategy): verify dist strategy artifacts

### DIFF
--- a/packages/path-strategy/package.json
+++ b/packages/path-strategy/package.json
@@ -59,6 +59,7 @@
   },
   "scripts": {
     "build": "vite build",
+    "postbuild": "node scripts/verify-dist.mjs",
     "test": "jest",
     "test:perf": "jest --config jest.perf.config.cjs",
     "bench:browser": "vite --config bench/vite.config.ts",

--- a/packages/path-strategy/scripts/verify-dist.mjs
+++ b/packages/path-strategy/scripts/verify-dist.mjs
@@ -1,0 +1,70 @@
+import { existsSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+
+const rootDir = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const distDir = resolve(rootDir, 'dist')
+
+if (!existsSync(distDir)) {
+  throw new Error('dist directory is missing. Run `pnpm run build` first.')
+}
+
+const localeCodes = ['en', 'zh']
+const locales = localeCodes.map((code) => ({ code }))
+const router = {
+  hasRoute: () => false,
+  resolve: (to) => {
+    if (typeof to === 'string') {
+      return { path: to, fullPath: to, params: {}, query: {}, hash: '' }
+    }
+
+    const path = to.path ?? '/'
+    return {
+      name: to.name ?? null,
+      path,
+      fullPath: to.fullPath ?? path,
+      params: to.params ?? {},
+      query: to.query ?? {},
+      hash: to.hash ?? '',
+    }
+  },
+}
+
+function createContext() {
+  return {
+    strategy: 'prefix_except_default',
+    defaultLocale: 'en',
+    locales,
+    localeCodes,
+    localizedRouteNamePrefix: 'localized-',
+    router,
+    globalLocaleRoutes: {
+      pricing: false,
+    },
+    routeLocales: {
+      account: ['en'],
+    },
+  }
+}
+
+function assertEqual(actual, expected, message) {
+  if (actual !== expected) {
+    throw new Error(`${message}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`)
+  }
+}
+
+function verifyRuntime(strategyModule, label) {
+  const Strategy = strategyModule.PrefixExceptDefaultPathStrategy ?? strategyModule.Strategy
+  const strategy = new Strategy(createContext())
+
+  assertEqual(strategy.shouldReturn404('/zh/pricing'), 'Unlocalized route cannot have locale prefix', `${label} checks localized unlocalized route`)
+  assertEqual(strategy.shouldReturn404('/zh/account'), 'Locale not allowed for this route', `${label} checks route locale restrictions`)
+}
+
+const esmPrefixExceptDefault = await import(pathToFileURL(resolve(distDir, 'prefix-except-default-strategy.mjs')).href)
+verifyRuntime(esmPrefixExceptDefault, 'esm')
+
+const require = createRequire(import.meta.url)
+const cjsPrefixExceptDefault = require(resolve(distDir, 'prefix-except-default-strategy.cjs'))
+verifyRuntime(cjsPrefixExceptDefault, 'cjs')


### PR DESCRIPTION
## Summary

- Add a post-build `@i18n-micro/path-strategy` dist smoke verifier.
- Exercise both ESM and CJS `prefix-except-default` package entrypoints after `vite build`.
- Cover the packaged runtime paths for unlocalized routes and route locale restrictions, which depend on the generated shared base chunk.

Fixes #222.

## Verification

- `pnpm --filter @i18n-micro/path-strategy run build`
- `pnpm --filter @i18n-micro/types run build`
- `pnpm --filter @i18n-micro/path-strategy run test -- --runInBand`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a post-build smoke test that verifies `@i18n-micro/path-strategy` dist artifacts for the `prefix-except-default` strategy in both ESM and CJS. Ensures runtime paths work after `vite` build, covering unlocalized routes and locale restrictions.

- New Features
  - Add `postbuild` hook to run `scripts/verify-dist.mjs` after `vite` build.
  - Verify ESM and CJS `prefix-except-default` entrypoints load from `dist`.
  - Assert runtime behavior for unlocalized routes and locale-restricted routes.

<sup>Written for commit 93ac3d659f49c7012fb08ed04b83dea11ab3052e. Summary will update on new commits. <a href="https://cubic.dev/pr/s00d/nuxt-i18n-micro/pull/223?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

