### PR TITLE
fix: add translation payload output controls

### DIFF
--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -901,6 +901,7 @@ Controls where pre-merged translation payload files are emitted during build.
   serverAssets?: boolean
   serverHandler?: boolean
   publicAssets?: boolean
+  prerenderRoutes?: boolean
   publicDir?: string
 }
 ```
@@ -911,11 +912,12 @@ Controls where pre-merged translation payload files are emitted during build.
 {
   serverAssets: true,
   serverHandler: true,
-  publicAssets: true
+  publicAssets: true,
+  prerenderRoutes: true
 }
 ```
 
-The defaults preserve the all-in-one behavior: translations are registered as Nitro server assets, the local `/{apiBaseUrl}/:page/:locale/data.json` handler is registered, and the merged files are copied to Nitro public assets during production builds.
+The defaults preserve the all-in-one behavior: translations are registered as Nitro server assets, the local `/{apiBaseUrl}/:page/:locale/data.json` handler is registered, data routes are added to prerender output, and the merged files are copied to Nitro public assets during production builds.
 
 For serverless deployments with large locale sets, you can disable the duplicated local outputs and serve translation payloads from a CDN or object storage:
 
@@ -926,22 +928,24 @@ i18n: {
   translationPayloads: {
     serverAssets: false,
     serverHandler: false,
-    publicAssets: false
+    publicAssets: false,
+    prerenderRoutes: false
   }
 }
 ```
 
-If you only want to avoid copying payloads into public assets while keeping the built-in server route, disable `publicAssets` only:
+If you only want to avoid writing payloads into public output while keeping the built-in server route for SSR/runtime requests, disable both public outputs:
 
 ```typescript
 i18n: {
   translationPayloads: {
-    publicAssets: false
+    publicAssets: false,
+    prerenderRoutes: false
   }
 }
 ```
 
-Use `publicDir` to change the public output folder when `publicAssets` is enabled. It defaults to `translationDir`.
+Use `publicDir` to change the public output folder when `publicAssets` is enabled. It defaults to `translationDir`. `publicAssets` controls the direct merged-directory copy, while `prerenderRoutes` controls generated `/{apiBaseUrl}/.../data.json` files such as `/_locales/index/en/data.json`.
 
 ### 🔒 Proxy & Security
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -890,6 +890,59 @@ When `apiBaseServerHost` is set, server-side translations will be fetched from `
 Use `apiBaseUrl` for path prefixes, `apiBaseClientHost` for client-side CDN/external domain hosting, and `apiBaseServerHost` for server-side CDN/external domain hosting. This allows you to use different CDNs for client and server requests.
 :::
 
+#### `translationPayloads`
+
+Controls where pre-merged translation payload files are emitted during build.
+
+**Type**:
+
+```typescript
+{
+  serverAssets?: boolean
+  serverHandler?: boolean
+  publicAssets?: boolean
+  publicDir?: string
+}
+```
+
+**Default**:
+
+```typescript
+{
+  serverAssets: true,
+  serverHandler: true,
+  publicAssets: true
+}
+```
+
+The defaults preserve the all-in-one behavior: translations are registered as Nitro server assets, the local `/{apiBaseUrl}/:page/:locale/data.json` handler is registered, and the merged files are copied to Nitro public assets during production builds.
+
+For serverless deployments with large locale sets, you can disable the duplicated local outputs and serve translation payloads from a CDN or object storage:
+
+```typescript
+i18n: {
+  apiBaseClientHost: 'https://cdn.example.com',
+  apiBaseServerHost: 'https://cdn.example.com',
+  translationPayloads: {
+    serverAssets: false,
+    serverHandler: false,
+    publicAssets: false
+  }
+}
+```
+
+If you only want to avoid copying payloads into public assets while keeping the built-in server route, disable `publicAssets` only:
+
+```typescript
+i18n: {
+  translationPayloads: {
+    publicAssets: false
+  }
+}
+```
+
+Use `publicDir` to change the public output folder when `publicAssets` is enabled. It defaults to `translationDir`.
+
 ### 🔒 Proxy & Security
 
 #### `metaTrustForwardedHost`

--- a/docs/guide/performance.md
+++ b/docs/guide/performance.md
@@ -249,12 +249,13 @@ export default defineNuxtConfig({
       serverAssets: false,
       serverHandler: false,
       publicAssets: false,
+      prerenderRoutes: false,
     },
   },
 })
 ```
 
-Keep `serverAssets` and `serverHandler` enabled when you rely on the built-in local `/{apiBaseUrl}/:page/:locale/data.json` route. Disable them when payloads are hosted externally and `apiBaseServerHost` points at that external origin.
+Keep `serverAssets` and `serverHandler` enabled when you rely on the built-in local `/{apiBaseUrl}/:page/:locale/data.json` route. Disable them when payloads are hosted externally and `apiBaseServerHost` points at that external origin. Disable `prerenderRoutes` when you do not want Nitro to materialize `/{apiBaseUrl}/.../data.json` files such as `/_locales/index/en/data.json` into public output.
 
 ## 📝 Tips for Maximizing Performance
 

--- a/docs/guide/performance.md
+++ b/docs/guide/performance.md
@@ -234,6 +234,28 @@ To optimize performance, `Nuxt I18n Micro` implements caching and supports pre-r
 - 🗄️ **Caching**: Translations are cached after the initial load, reducing the need for subsequent requests and improving response times.
 - 🏁 **Pre-rendering**: During the build process, translation files for all configured locales and routes can be pre-rendered. This eliminates the need for runtime requests, ensuring that translations are served quickly and efficiently.
 
+### ☁️ Serverless Payload Output
+
+By default, pre-merged translation payloads are emitted in multiple places so SSR, static generation, and local data routes work without extra setup. Large applications with many locales and page-level payloads may want tighter control, especially on serverless platforms where every Nitro server asset increases the Worker bundle.
+
+Use `translationPayloads` to disable outputs you do not need:
+
+```typescript
+export default defineNuxtConfig({
+  i18n: {
+    apiBaseClientHost: 'https://cdn.example.com',
+    apiBaseServerHost: 'https://cdn.example.com',
+    translationPayloads: {
+      serverAssets: false,
+      serverHandler: false,
+      publicAssets: false,
+    },
+  },
+})
+```
+
+Keep `serverAssets` and `serverHandler` enabled when you rely on the built-in local `/{apiBaseUrl}/:page/:locale/data.json` route. Disable them when payloads are hosted externally and `apiBaseServerHost` points at that external origin.
+
 ## 📝 Tips for Maximizing Performance
 
 Here are a few tips to ensure you get the best performance out of `Nuxt I18n Micro`:

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -275,6 +275,15 @@ export interface ModuleOptions {
   translationDir?: string
 
   /**
+   * Controls how pre-merged translation payload files are emitted during build.
+   *
+   * Keep the defaults for the existing all-in-one behavior. For serverless or CDN-backed
+   * deployments, disable individual outputs to avoid duplicating large locale payloads in
+   * both Nitro server assets and public assets.
+   */
+  translationPayloads?: TranslationPayloadOptions
+
+  /**
    * Automatically detect the user's preferred language from the `Accept-Language` HTTP header.
    * Used in combination with `autoDetectPath` to decide when detection occurs.
    * @default true
@@ -454,6 +463,35 @@ export interface ModuleOptions {
    * Contents may change or be removed without notice between minor versions.
    */
   experimental?: Record<string, unknown>
+}
+
+export interface TranslationPayloadOptions {
+  /**
+   * Register the pre-merged translations directory as Nitro server assets.
+   * Required for the built-in local `_locales` server route and server middleware unless
+   * translations are fetched from `apiBaseServerHost`.
+   * @default true
+   */
+  serverAssets?: boolean
+
+  /**
+   * Register the built-in server route at `/{apiBaseUrl}/:page/:locale/data.json`.
+   * Disable this when translation payloads are served from an external host/CDN.
+   * @default true
+   */
+  serverHandler?: boolean
+
+  /**
+   * Copy the pre-merged translations directory into Nitro public assets during production builds.
+   * @default true
+   */
+  publicAssets?: boolean
+
+  /**
+   * Public output directory for copied translation payloads, relative to Nitro's public directory.
+   * Defaults to `translationDir`.
+   */
+  publicDir?: string
 }
 
 /**

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -488,6 +488,14 @@ export interface TranslationPayloadOptions {
   publicAssets?: boolean
 
   /**
+   * Add translation data routes to Nuxt/Nitro prerender output.
+   * Disable this when `_locales` payloads are served from an external host/CDN or should not be
+   * materialized into public output.
+   * @default true
+   */
+  prerenderRoutes?: boolean
+
+  /**
    * Public output directory for copied translation payloads, relative to Nitro's public directory.
    * Defaults to `translationDir`.
    */

--- a/src/module.ts
+++ b/src/module.ts
@@ -54,6 +54,7 @@ export function resolveTranslationPayloadOptions(options: ModuleOptions) {
     serverAssets: options.translationPayloads?.serverAssets !== false,
     serverHandler: options.translationPayloads?.serverHandler !== false,
     publicAssets: options.translationPayloads?.publicAssets !== false,
+    prerenderRoutes: options.translationPayloads?.prerenderRoutes !== false,
     publicDir: options.translationPayloads?.publicDir,
   }
 }
@@ -241,6 +242,7 @@ export default defineNuxtModule<ModuleOptions>({
       serverAssets: true,
       serverHandler: true,
       publicAssets: true,
+      prerenderRoutes: true,
     },
     routesLocaleLinks: {},
     globalLocaleRoutes: {},
@@ -651,6 +653,8 @@ declare module '#i18n-internal/plural' {
     })
 
     const addDataRoutes = (pages: NuxtPage[] = []) => {
+      if (!translationPayloads.prerenderRoutes) return
+
       const pagesForDataRoutes = pages.filter((p) => p.name !== undefined && (!options.routesLocaleLinks || !options.routesLocaleLinks[p.name!]))
       const dataRoutes = routeGenerator.generateDataRoutes(pagesForDataRoutes, apiBaseUrl, !!options.disablePageLocales)
       addPrerenderRoutes(dataRoutes)

--- a/src/module.ts
+++ b/src/module.ts
@@ -49,6 +49,20 @@ interface PreMergeLocaleInfo {
 
 const DEFAULT_CANONICAL_QUERY_WHITELIST = ['page', 'sort', 'filter', 'search', 'q', 'query', 'tag']
 
+export function resolveTranslationPayloadOptions(options: ModuleOptions) {
+  return {
+    serverAssets: options.translationPayloads?.serverAssets !== false,
+    serverHandler: options.translationPayloads?.serverHandler !== false,
+    publicAssets: options.translationPayloads?.publicAssets !== false,
+    publicDir: options.translationPayloads?.publicDir,
+  }
+}
+
+export function resolveTranslationPayloadPublicDir(outputPublicDir: string | undefined, options: ModuleOptions): string {
+  const translationPayloads = resolveTranslationPayloadOptions(options)
+  return path.join(outputPublicDir ?? './dist', translationPayloads.publicDir ?? options.translationDir ?? 'locales')
+}
+
 /**
  * Pre-merge all translation files at build time.
  *
@@ -223,6 +237,11 @@ export default defineNuxtModule<ModuleOptions>({
     apiBaseUrl: '_locales',
     apiBaseClientHost: undefined,
     apiBaseServerHost: undefined,
+    translationPayloads: {
+      serverAssets: true,
+      serverHandler: true,
+      publicAssets: true,
+    },
     routesLocaleLinks: {},
     globalLocaleRoutes: {},
     canonicalQueryWhitelist: undefined,
@@ -264,6 +283,7 @@ export default defineNuxtModule<ModuleOptions>({
     // Executed in build:before hook to ensure buildDir exists.
     const mergedLocalesDir = resolve(nuxt.options.buildDir, 'i18n-merged')
     const translationDirName = options.translationDir || 'locales'
+    const translationPayloads = resolveTranslationPayloadOptions(options)
     const localeInfos: PreMergeLocaleInfo[] = (options.locales ?? []).map((l) =>
       typeof l === 'string' ? { code: l } : { code: l.code, fallbackLocale: l.fallbackLocale },
     )
@@ -543,10 +563,12 @@ export function getI18nPrivateConfig() { return __privateConfig }
       order: 10,
     })
 
-    addServerHandler({
-      route: `/${apiBaseUrl}/:page/:locale/data.json`,
-      handler: resolver.resolve('./runtime/server/routes/i18n'),
-    })
+    if (translationPayloads.serverHandler) {
+      addServerHandler({
+        route: `/${apiBaseUrl}/:page/:locale/data.json`,
+        handler: resolver.resolve('./runtime/server/routes/i18n'),
+      })
+    }
 
     if (options.components !== false) {
       addComponentsDir({
@@ -679,14 +701,16 @@ declare module '#i18n-internal/plural' {
       nitroConfig.alias['#i18n-internal/strategy'] = strategyTemplate.dst
       nitroConfig.alias['#i18n-internal/config'] = configTemplate.dst
 
-      // Mount pre-merged translation directory as a single server asset.
-      // Translations from all layers were merged at build time in preMergeLocales().
-      // This is critical for serverless support (Cloudflare Workers) where there is no direct FS access.
-      nitroConfig.serverAssets = nitroConfig.serverAssets || []
-      nitroConfig.serverAssets.push({
-        baseName: 'i18n',
-        dir: mergedLocalesDir,
-      })
+      if (translationPayloads.serverAssets) {
+        // Mount pre-merged translation directory as a single server asset.
+        // Translations from all layers were merged at build time in preMergeLocales().
+        // This is critical for serverless support (Cloudflare Workers) where there is no direct FS access.
+        nitroConfig.serverAssets = nitroConfig.serverAssets || []
+        nitroConfig.serverAssets.push({
+          baseName: 'i18n',
+          dir: mergedLocalesDir,
+        })
+      }
 
       if (nitroConfig.imports) {
         nitroConfig.imports.presets = nitroConfig.imports.presets || []
@@ -735,8 +759,8 @@ declare module '#i18n-internal/plural' {
 
     nuxt.hook('nitro:build:public-assets', (nitro) => {
       const isProd = nuxt.options.dev === false
-      if (isProd) {
-        const publicDir = path.join(nitro.options.output.publicDir ?? './dist', options.translationDir ?? 'locales')
+      if (isProd && translationPayloads.publicAssets) {
+        const publicDir = resolveTranslationPayloadPublicDir(nitro.options.output.publicDir, options)
 
         try {
           // Copy pre-merged translations (already contains all layers)

--- a/src/runtime/plugins/01.plugin.ts
+++ b/src/runtime/plugins/01.plugin.ts
@@ -136,6 +136,8 @@ export default defineNuxtPlugin(async (nuxtApp) => {
   const loadOptions = {
     apiBaseUrl: i18nConfig.apiBaseUrl ?? '_locales',
     baseURL: runtimeConfig.app.baseURL,
+    apiBaseClientHost: i18nConfig.apiBaseClientHost,
+    apiBaseServerHost: i18nConfig.apiBaseServerHost,
     dateBuild: i18nConfig.dateBuild,
   }
 

--- a/src/runtime/server/utils/server-loader.ts
+++ b/src/runtime/server/utils/server-loader.ts
@@ -42,6 +42,20 @@ function toTranslations(data: unknown): Translations {
   return {}
 }
 
+async function fetchExternalTranslations(config: ModuleOptionsExtend, locale: string, routeName: string): Promise<Translations> {
+  const apiBaseServerHost = config.apiBaseServerHost
+  if (!apiBaseServerHost) return {}
+
+  const apiBaseUrl = config.apiBaseUrl ?? '_locales'
+  const path = `/${apiBaseUrl}/${routeName}/${locale}/data.json`
+  const data = await $fetch(path.replace(/\/{2,}/g, '/'), {
+    baseURL: apiBaseServerHost,
+    params: config.dateBuild ? { v: config.dateBuild } : undefined,
+  })
+
+  return toTranslations(data)
+}
+
 // ============================================================================
 // PUBLIC API
 // ============================================================================
@@ -70,6 +84,16 @@ export async function loadTranslationsFromServer(locale: string, routeName: stri
   const routesLocaleLinks = config.routesLocaleLinks || {}
   const resolvedPage = routesLocaleLinks[routeName] || routeName
   const normalizedPage = resolvedPage.replace(/\//g, ':')
+
+  if (config.apiBaseServerHost) {
+    const data = await fetchExternalTranslations(config, locale, resolvedPage)
+    const json = JSON.stringify(data).replace(/</g, '\\u003c')
+    const entry = { data, json }
+
+    cc.set(cacheKey, entry)
+    return entry
+  }
+
   const key = `${ASSETS_PREFIX}:pages:${normalizedPage}:${locale}.json`
 
   const loaded = await storage.getItem(key)

--- a/src/runtime/server/utils/server-loader.ts
+++ b/src/runtime/server/utils/server-loader.ts
@@ -48,12 +48,16 @@ async function fetchExternalTranslations(config: ModuleOptionsExtend, locale: st
 
   const apiBaseUrl = config.apiBaseUrl ?? '_locales'
   const path = `/${apiBaseUrl}/${routeName}/${locale}/data.json`
-  const data = await $fetch(path.replace(/\/{2,}/g, '/'), {
-    baseURL: apiBaseServerHost,
-    params: config.dateBuild ? { v: config.dateBuild } : undefined,
-  })
+  try {
+    const data = await $fetch(path.replace(/\/{2,}/g, '/'), {
+      baseURL: apiBaseServerHost,
+      params: config.dateBuild ? { v: config.dateBuild } : undefined,
+    })
 
-  return toTranslations(data)
+    return toTranslations(data)
+  } catch {
+    return {}
+  }
 }
 
 // ============================================================================

--- a/src/runtime/utils/storage.ts
+++ b/src/runtime/utils/storage.ts
@@ -14,6 +14,8 @@ declare global {
 export interface LoadOptions {
   apiBaseUrl: string
   baseURL: string
+  apiBaseClientHost?: string
+  apiBaseServerHost?: string
   dateBuild?: string | number
 }
 
@@ -65,12 +67,13 @@ class TranslationStorage {
   // ==========================================================================
 
   private async fetchTranslations(locale: string, routeName: string | undefined, options: LoadOptions): Promise<Record<string, unknown>> {
-    const { apiBaseUrl, baseURL, dateBuild } = options
+    const { apiBaseUrl, baseURL, apiBaseClientHost, apiBaseServerHost, dateBuild } = options
     const page = routeName || 'index'
     const path = `/${apiBaseUrl}/${page}/${locale}/data.json`
+    const payloadBaseURL = import.meta.server ? apiBaseServerHost : apiBaseClientHost
 
     return (await $fetch(path.replace(/\/{2,}/g, '/'), {
-      baseURL,
+      baseURL: payloadBaseURL ?? baseURL,
       params: dateBuild ? { v: dateBuild } : undefined,
     })) as Record<string, unknown>
   }

--- a/test/translation-payloads.test.ts
+++ b/test/translation-payloads.test.ts
@@ -8,6 +8,7 @@ describe('translationPayloads build options', () => {
       serverAssets: true,
       serverHandler: true,
       publicAssets: true,
+      prerenderRoutes: true,
       publicDir: undefined,
     })
   })
@@ -19,6 +20,7 @@ describe('translationPayloads build options', () => {
           serverAssets: false,
           serverHandler: false,
           publicAssets: false,
+          prerenderRoutes: false,
           publicDir: '_payloads',
         },
       }),
@@ -26,6 +28,7 @@ describe('translationPayloads build options', () => {
       serverAssets: false,
       serverHandler: false,
       publicAssets: false,
+      prerenderRoutes: false,
       publicDir: '_payloads',
     })
   })

--- a/test/translation-payloads.test.ts
+++ b/test/translation-payloads.test.ts
@@ -1,0 +1,40 @@
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { resolveTranslationPayloadOptions, resolveTranslationPayloadPublicDir } from '../src/module'
+
+describe('translationPayloads build options', () => {
+  it('keeps all local payload outputs enabled by default', () => {
+    expect(resolveTranslationPayloadOptions({})).toEqual({
+      serverAssets: true,
+      serverHandler: true,
+      publicAssets: true,
+      publicDir: undefined,
+    })
+  })
+
+  it('can disable individual local payload outputs', () => {
+    expect(
+      resolveTranslationPayloadOptions({
+        translationPayloads: {
+          serverAssets: false,
+          serverHandler: false,
+          publicAssets: false,
+          publicDir: '_payloads',
+        },
+      }),
+    ).toEqual({
+      serverAssets: false,
+      serverHandler: false,
+      publicAssets: false,
+      publicDir: '_payloads',
+    })
+  })
+
+  it('resolves the public payload directory from publicDir, translationDir, or locales', () => {
+    expect(resolveTranslationPayloadPublicDir('/dist/public', {})).toBe(join('/dist/public', 'locales'))
+    expect(resolveTranslationPayloadPublicDir('/dist/public', { translationDir: 'i18n/locales' })).toBe(join('/dist/public', 'i18n/locales'))
+    expect(resolveTranslationPayloadPublicDir('/dist/public', { translationPayloads: { publicDir: '_payloads' } })).toBe(
+      join('/dist/public', '_payloads'),
+    )
+  })
+})


### PR DESCRIPTION
## Summary

Fixes #225.

This PR adds explicit controls for where pre-merged translation payloads are emitted:

- `translationPayloads.serverAssets` controls Nitro `serverAssets` registration.
- `translationPayloads.serverHandler` controls the built-in `/{apiBaseUrl}/:page/:locale/data.json` route.
- `translationPayloads.publicAssets` controls the production public asset copy.
- `translationPayloads.publicDir` optionally overrides the public output folder.

All options default to the current behavior, so existing apps continue to get server assets, the local data route, and the public copy.

## Why

Large serverless apps can end up embedding/copying the same pre-merged translation matrix multiple times. In the linked Cloudflare Workers case, `32 locales x 28 page contexts` produced hundreds of JSON payloads and enough output to fail deploys or exceed runtime memory limits.

With this change, apps can keep the built-in local route:

```ts
i18n: {
  translationPayloads: {
    publicAssets: false,
  },
}
```

Or serve payloads from CDN/object storage and avoid local Worker payload output:

```ts
i18n: {
  apiBaseClientHost: 'https://cdn.example.com',
  apiBaseServerHost: 'https://cdn.example.com',
  translationPayloads: {
    serverAssets: false,
    serverHandler: false,
    publicAssets: false,
  },
}
```

The existing `apiBaseClientHost` / `apiBaseServerHost` options are also now wired into the runtime loaders, so external payload hosting works for both browser fetches and SSR/server-side translation loading.

## Verification

- `pnpm exec vitest run test/translation-payloads.test.ts`
- `pnpm exec biome check src/module.ts src/runtime/utils/storage.ts src/runtime/server/utils/server-loader.ts src/runtime/plugins/01.plugin.ts packages/types/src/index.ts test/translation-payloads.test.ts docs/guide/getting-started.md docs/guide/performance.md`
- `pnpm exec nuxt-module-build build --stub`

Notes from this Windows clone:

- `pnpm run typecheck` is blocked by existing unresolved workspace package dist/types in playground projects unless the full workspace is built.
- `pnpm --filter "./packages/**" run build` is blocked by an unrelated `@i18n-micro/devtools-ui` Rollup error: `Entry module "vite/plugin.ts" cannot be external`.
- `vitest run test/serverless-cache.test.ts` is blocked by `@nuxt/test-utils` failing to resolve `#dirs` in this environment.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds controls for where pre-merged translation payloads are emitted (including prerendered routes) and wires external host options into runtime loaders. This helps large serverless apps avoid duplicate payloads and oversized bundles while keeping defaults unchanged.

- **New Features**
  - Added `i18n.translationPayloads` with `serverAssets`, `serverHandler`, `publicAssets`, `prerenderRoutes`, and `publicDir` to control Nitro server assets, the `/{apiBaseUrl}/:page/:locale/data.json` route, prerendered data files, and public asset copy/output folder.
  - Runtime loaders now honor `apiBaseClientHost` and `apiBaseServerHost` for both client and SSR fetches, enabling external payload hosting.

<sup>Written for commit a8987a7e714d1ee3df8ef1530ed2603dac60806a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/s00d/nuxt-i18n-micro/pull/226?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

