### PR TITLE
fix(runtime): use RelativeTimeFormatOptions for $tdr injection

### DIFF
--- a/src/runtime/plugins/01.plugin.ts
+++ b/src/runtime/plugins/01.plugin.ts
@@ -195,7 +195,7 @@ export interface PluginsInjections {
   $tc: (key: string, params: number | Params, defaultValue?: string) => string
   $tn: (value: number, options?: Intl.NumberFormatOptions) => string
   $td: (value: Date | number | string, options?: Intl.DateTimeFormatOptions) => string
-  $tdr: (value: Date | number | string, options?: Intl.DateTimeFormatOptions) => string
+  $tdr: (value: Date | number | string, options?: Intl.RelativeTimeFormatOptions) => string
   $has: (key: string) => boolean
   $mergeTranslations: (newTranslations: Translations) => void
   $switchLocaleRoute: (locale: string) => RouteLocationRaw


### PR DESCRIPTION
<!-- Thank you for contributing! 🎉 -->

## 📝 Description

Fixes the typing for the injected $tdr helper in runtime plugin injections.

Previously, $tdr accepted Intl.DateTimeFormatOptions, which is incorrect for relative-time formatting and causes TypeScript errors for valid options such as numeric and style.

This PR updates the type to Intl.RelativeTimeFormatOptions so editor hints and type checking align with the actual API usage.

## 🔗 Related Issue

Closes #231 

## 🎯 Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance
- [ ] ✅ Tests

## 🧪 Testing

### Environment

- **OS**: Ubuntu 24.04
- **Node**: 24.x
- **Nuxt**: 4.x

### Tested

- [x] Existing tests pass (pnpm test)
- [ ] Added new tests
- [ ] Manual testing
- [ ] Tested in production build

## 📋 Checklist

- [x] Code follows style guidelines
- [x] Self-reviewed my code
- [ ] Commented complex code
- [ ] Updated documentation
- [x] Updated types (if needed)
- [x] No new warnings/errors
- [x] Tests pass

## 🖼️ Screenshots (optional)

<details>
<summary>Before / After</summary>

Not applicable (type-only change).

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix typing for runtime `$tdr` injection by using `Intl.RelativeTimeFormatOptions` instead of `Intl.DateTimeFormatOptions`. This resolves TypeScript errors and aligns editor hints with relative time options like `numeric` and `style`.

<sup>Written for commit ec1befaaf98239a99cca2909b59a0fe74dce08d0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/s00d/nuxt-i18n-micro/pull/232?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

