### PR TITLE
fix(i18n): apply cacheMaxSize to client chunk Map

### DIFF
--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -1292,10 +1292,15 @@ export default defineNuxtConfig({
 ```
 
 ::: tip When to use
-For most projects the default (unlimited, no expiration) is fine — translations are small and finite. However, if your project has **thousands of pages** with `disablePageLocales: false` and **many locales**, the server cache can grow significantly. In long-running Node.js servers this may lead to excessive memory usage.
+For most projects the default (unlimited, no expiration) is fine — route names are finite (`product-id`, not `product-123`), so the client chunk Map stays bounded by pages × locales. Set a limit when you have **many locales × many page dictionaries** and long-lived Node or SPA sessions.
 
-- **`cacheMaxSize`** — caps the number of cached entries. Useful for bounding memory.
-- **`cacheTtl`** — ensures stale translations are eventually reloaded from storage. Useful for serverless environments or when translations change at runtime.
+`cacheMaxSize` caps:
+
+1. **Fetch / server `CacheControl`** (HTTP payload and server loader caches)
+2. **Client chunk Map** (`NuxtI18n.storage.translations`) — oldest unused `(locale, route)` chunks are evicted; the active page chunk is kept
+
+- **`cacheMaxSize`** — caps entries in those caches. Useful for bounding memory.
+- **`cacheTtl`** — expires fetch/server cache entries (not the live view layer). Useful for serverless or runtime-updated translations.
 
 **Formula for estimating max entries**: `number_of_locales × (number_of_pages + 1)`. For example, 10 locales × 500 pages = ~5010 entries.
 :::

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -1297,7 +1297,7 @@ For most projects the default (unlimited, no expiration) is fine — route names
 `cacheMaxSize` caps:
 
 1. **Fetch / server `CacheControl`** (HTTP payload and server loader caches)
-2. **Client chunk Map** (`NuxtI18n.storage.translations`) — oldest unused `(locale, route)` chunks are evicted; the active page chunk is kept
+2. **Client chunk Map** (`NuxtI18n.storage.translations`) — oldest unused `(locale, route)` chunks are evicted; the just-written and active page keys are preferred. If the limit cannot hold both (e.g. `cacheMaxSize: 1`), the just-written key wins so the bound is enforced — active `$t` still uses the view layer
 
 - **`cacheMaxSize`** — caps entries in those caches. Useful for bounding memory.
 - **`cacheTtl`** — expires fetch/server cache entries (not the live view layer). Useful for serverless or runtime-updated translations.

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -1297,7 +1297,7 @@ For most projects the default (unlimited, no expiration) is fine — route names
 `cacheMaxSize` caps:
 
 1. **Fetch / server `CacheControl`** (HTTP payload and server loader caches)
-2. **Client chunk Map** (`NuxtI18n.storage.translations`) — oldest unused `(locale, route)` chunks are evicted; the just-written and active page keys are preferred. If the limit cannot hold both (e.g. `cacheMaxSize: 1`), the just-written key wins so the bound is enforced — active `$t` still uses the view layer
+2. **Client chunk Map** (`NuxtI18n.storage.translations`) — oldest (by write order) `(locale, route)` chunks are FIFO-evicted; the just-written and active page keys are preferred. If the limit cannot hold both (e.g. `cacheMaxSize: 1`), the just-written key wins so the bound is enforced — active `$t` still uses the view layer
 
 - **`cacheMaxSize`** — caps entries in those caches. Useful for bounding memory.
 - **`cacheTtl`** — expires fetch/server cache entries (not the live view layer). Useful for serverless or runtime-updated translations.

--- a/docs/news/index.md
+++ b/docs/news/index.md
@@ -6,6 +6,14 @@ outline: 'deep'
 
 # News
 
+## `cacheMaxSize` also caps client chunk Map
+
+**Date**: 2026-08-05
+
+**Version**: unreleased
+
+`i18n.cacheMaxSize` already limited fetch/server `CacheControl` caches. It now also FIFO-evicts entries in the client `NuxtI18n.storage.translations` Map (`locale:route` chunks), keeping the active page. Default `0` remains unlimited — route names from Vue Router are finite, so this is an optional bound for long SPA sessions with many page dictionaries.
+
 ## Nuxt I18n Micro v3.26.1 — Vue DevTools live inspector
 
 **Date**: 2026-08-05

--- a/docs/news/index.md
+++ b/docs/news/index.md
@@ -12,7 +12,7 @@ outline: 'deep'
 
 **Version**: unreleased
 
-`i18n.cacheMaxSize` already limited fetch/server `CacheControl` caches. It now also FIFO-evicts entries in the client `NuxtI18n.storage.translations` Map (`locale:route` chunks), keeping the active page. Default `0` remains unlimited — route names from Vue Router are finite, so this is an optional bound for long SPA sessions with many page dictionaries.
+`i18n.cacheMaxSize` already limited fetch/server `CacheControl` caches. It now also FIFO-evicts entries in the client `NuxtI18n.storage.translations` Map (`locale:route` chunks), preferring the active and just-written keys. When the limit cannot hold both (e.g. `1`), the just-written key wins so the bound is enforced. Default `0` remains unlimited — route names from Vue Router are finite, so this is an optional bound for long SPA sessions with many page dictionaries.
 
 ## Nuxt I18n Micro v3.26.1 — Vue DevTools live inspector
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuxt-i18n-micro",
-  "version": "3.27.0",
+  "version": "3.27.1",
   "description": "Fast, lightweight i18n for Nuxt with strategy-based routing and minimal overhead.",
   "keywords": [
     "i18n",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuxt-i18n-micro",
-  "version": "3.27.1",
+  "version": "3.27.0",
   "description": "Fast, lightweight i18n for Nuxt with strategy-based routing and minimal overhead.",
   "keywords": [
     "i18n",

--- a/src/runtime/devtools/vue-devtools.ts
+++ b/src/runtime/devtools/vue-devtools.ts
@@ -136,7 +136,7 @@ function buildNodeState(i18n: NuxtI18n, i18nConfig: ModuleOptionsExtend, nodeId:
     const value = segments.length ? getByInspectorPath(source, segments) : source
 
     if (isPlainObject(value)) {
-      return { [(segments.join('.') || 'root')]: objectToStateEntries(value) }
+      return { [segments.join('.') || 'root']: objectToStateEntries(value) }
     }
 
     return {

--- a/src/runtime/plugins/01.plugin.ts
+++ b/src/runtime/plugins/01.plugin.ts
@@ -53,6 +53,7 @@ export default defineNuxtPlugin(async (nuxtApp) => {
   const i18n = new NuxtI18n({
     plural,
     missingWarn: i18nConfig.missingWarn ?? true,
+    cacheMaxSize: i18nConfig.cacheMaxSize ?? 0,
     getCustomMissingHandler: () => customMissingHandler.value,
     numberFormats: i18nConfig.numberFormats,
     datetimeFormats: i18nConfig.datetimeFormats,

--- a/src/runtime/utils/nuxt-i18n.ts
+++ b/src/runtime/utils/nuxt-i18n.ts
@@ -79,10 +79,18 @@ export type LoadTranslationsChunk = (locale: string, routeName?: string) => Prom
 /** Why the active translation context changed — used by Vue DevTools timeline. */
 export type I18nContextChangeReason = 'load' | 'refresh'
 
-export interface NuxtI18nOptions extends BaseI18nOptions {}
+export interface NuxtI18nOptions extends BaseI18nOptions {
+  /**
+   * Cap for `storage.translations` chunk entries (`locale:route`).
+   * `0` means no limit. Same module option as the fetch/server `CacheControl` layers.
+   * @default 0
+   */
+  cacheMaxSize?: number
+}
 
 export class NuxtI18n extends BaseI18n {
   readonly storage: TranslationStorage
+  private readonly cacheMaxSize: number
   private readonly contextSignal: ShallowRef<number>
   private cachedTranslations: Record<string, unknown> = {}
   /**
@@ -99,12 +107,14 @@ export class NuxtI18n extends BaseI18n {
   private missingKeyListener?: (locale: string, key: string, routeName: string) => void
 
   constructor(options: NuxtI18nOptions = {}) {
+    const { cacheMaxSize = 0, ...baseOptions } = options
     const storage: TranslationStorage = {
       translations: new Map<string, Translations>(),
     }
 
-    super({ ...options, storage })
+    super({ ...baseOptions, storage })
     this.storage = storage
+    this.cacheMaxSize = cacheMaxSize
     this.contextSignal = shallowRef(0)
   }
 
@@ -121,7 +131,9 @@ export class NuxtI18n extends BaseI18n {
   }
 
   setChunk(locale: string, routeName: string | undefined, data: Record<string, unknown>): void {
-    this.storage.translations.set(this.getCacheKey(locale, routeName), data as Translations)
+    const key = this.getCacheKey(locale, routeName)
+    this.storage.translations.set(key, data as Translations)
+    this.evictChunks(key)
   }
 
   /**
@@ -134,11 +146,14 @@ export class NuxtI18n extends BaseI18n {
    * Existing entries win: anything already loaded is kept as-is.
    */
   seedChunks(chunks: Record<string, Record<string, unknown>>): void {
+    let lastKey = ''
     for (const [cacheKey, data] of Object.entries(chunks)) {
       if (!this.storage.translations.has(cacheKey)) {
         this.storage.translations.set(cacheKey, data as Translations)
+        lastKey = cacheKey
       }
     }
+    if (lastKey) this.evictChunks(lastKey)
   }
 
   hasChunk(locale: string, routeName?: string): boolean {
@@ -150,7 +165,24 @@ export class NuxtI18n extends BaseI18n {
     const existing = (this.storage.translations.get(cacheKey) ?? {}) as Record<string, unknown>
     const merged = mergeTranslationChunk(existing, data)
     this.storage.translations.set(cacheKey, merged as Translations)
+    this.evictChunks(cacheKey)
     return merged
+  }
+
+  /**
+   * FIFO eviction for `storage.translations` when `cacheMaxSize` is set.
+   * Keeps the just-written key and the active page chunk so `$t` stays valid.
+   */
+  private evictChunks(keep: string): void {
+    const max = this.cacheMaxSize
+    if (max <= 0 || this.storage.translations.size <= max) return
+
+    const current = this.getCacheKey(this.currentLocale, this.currentRouteName)
+    for (const key of this.storage.translations.keys()) {
+      if (this.storage.translations.size <= max) break
+      if (key === keep || key === current) continue
+      this.storage.translations.delete(key)
+    }
   }
 
   getLocale(): string {

--- a/src/runtime/utils/nuxt-i18n.ts
+++ b/src/runtime/utils/nuxt-i18n.ts
@@ -171,7 +171,10 @@ export class NuxtI18n extends BaseI18n {
 
   /**
    * FIFO eviction for `storage.translations` when `cacheMaxSize` is set.
-   * Keeps the just-written key and the active page chunk so `$t` stays valid.
+   * Prefers keeping the just-written key and the active page chunk. When those
+   * two differ and `max` cannot hold both (e.g. `cacheMaxSize: 1`), the just-written
+   * key wins so the configured bound is always enforced. Active `$t` still resolves
+   * via `cachedTranslations` / `outgoingTranslations` even if the Map drops the old key.
    */
   private evictChunks(keep: string): void {
     const max = this.cacheMaxSize
@@ -181,6 +184,15 @@ export class NuxtI18n extends BaseI18n {
     for (const key of this.storage.translations.keys()) {
       if (this.storage.translations.size <= max) break
       if (key === keep || key === current) continue
+      this.storage.translations.delete(key)
+    }
+
+    // Protected set can exceed max when keep !== current (prefetch / seed while another
+    // page is active). Drop everything except `keep` until the bound holds.
+    if (this.storage.translations.size <= max) return
+    for (const key of this.storage.translations.keys()) {
+      if (this.storage.translations.size <= max) break
+      if (key === keep) continue
       this.storage.translations.delete(key)
     }
   }
@@ -238,13 +250,14 @@ export class NuxtI18n extends BaseI18n {
    * and correct for the short hot-reload window.
    */
   applySwitchContext(locale: string, routeName: string | undefined, data: Record<string, unknown>): void {
-    this.setChunk(locale, routeName, data)
-
+    // Stash / swap the view layer before setChunk so eviction sees keep === current
+    // (otherwise cacheMaxSize: 1 would protect both the old and new route keys).
     this.outgoingTranslations = this.currentLocale === locale ? this.cachedTranslations : null
     this.cachedTranslations = data
 
     this.currentLocale = locale
     this.currentRouteName = routeName || ''
+    this.setChunk(locale, routeName, data)
     triggerRef(this.contextSignal)
     this.notifyContextChange('load')
   }

--- a/test/nuxt-i18n.test.ts
+++ b/test/nuxt-i18n.test.ts
@@ -173,6 +173,26 @@ describe('NuxtI18n', () => {
     expect(i18n.storage.translations.size).toBe(20)
   })
 
+  it('cacheMaxSize 1 enforces a single Map entry across navigations', () => {
+    const i18n = new NuxtI18n({ missingWarn: false, cacheMaxSize: 1 })
+
+    i18n.applySwitchContext('en', 'page-a', { title: 'A' })
+    expect(i18n.storage.translations.size).toBe(1)
+    expect(i18n.t('title')).toBe('A')
+
+    i18n.applySwitchContext('en', 'page-b', { title: 'B' })
+    expect(i18n.storage.translations.size).toBe(1)
+    expect(i18n.storage.translations.has(i18n.getCacheKey('en', 'page-b'))).toBe(true)
+    expect(i18n.t('title')).toBe('B')
+
+    // Prefetch of another route while still on page-b: just-written wins, bound stays 1.
+    i18n.setChunk('en', 'page-c', { title: 'C' })
+    expect(i18n.storage.translations.size).toBe(1)
+    expect(i18n.storage.translations.has(i18n.getCacheKey('en', 'page-c'))).toBe(true)
+    // View layer is independent of the Map eviction.
+    expect(i18n.t('title')).toBe('B')
+  })
+
   it('onContextChange reports load vs refresh reasons', () => {
     const i18n = new NuxtI18n({ missingWarn: false })
     const reasons: string[] = []

--- a/test/nuxt-i18n.test.ts
+++ b/test/nuxt-i18n.test.ts
@@ -146,6 +146,33 @@ describe('NuxtI18n', () => {
     expect(i18n.getChunk('en', 'index')).toEqual({})
   })
 
+  it('cacheMaxSize evicts oldest chunks but keeps the active page', () => {
+    const i18n = new NuxtI18n({ missingWarn: false, cacheMaxSize: 3 })
+
+    for (let n = 0; n < 20; n++) {
+      i18n.setChunk('en', `page-${n}`, { title: `Page ${n}` })
+    }
+    expect(i18n.storage.translations.size).toBeLessThanOrEqual(3)
+
+    i18n.applySwitchContext('en', 'page-19', i18n.getChunk('en', 'page-19'))
+    expect(i18n.t('title')).toBe('Page 19')
+
+    for (let n = 0; n < 10; n++) {
+      i18n.setChunk('en', `extra-${n}`, { title: `Extra ${n}` })
+    }
+    expect(i18n.storage.translations.size).toBeLessThanOrEqual(3)
+    expect(i18n.storage.translations.has(i18n.getCacheKey('en', 'page-19'))).toBe(true)
+    expect(i18n.t('title')).toBe('Page 19')
+  })
+
+  it('cacheMaxSize 0 leaves the chunk map unlimited', () => {
+    const i18n = new NuxtI18n({ missingWarn: false, cacheMaxSize: 0 })
+    for (let n = 0; n < 20; n++) {
+      i18n.setChunk('en', `page-${n}`, { title: `Page ${n}` })
+    }
+    expect(i18n.storage.translations.size).toBe(20)
+  })
+
   it('onContextChange reports load vs refresh reasons', () => {
     const i18n = new NuxtI18n({ missingWarn: false })
     const reasons: string[] = []


### PR DESCRIPTION
## Summary
- `i18n.cacheMaxSize` now FIFO-evicts entries in `NuxtI18n.storage.translations` (`locale:route` chunks), keeping the just-written and active page keys.
- Default `0` still means unlimited; fetch/server `CacheControl` wiring unchanged.
- Docs tip + news note; unit coverage for limit / active page / unlimited.

## Test plan
- [x] `pnpm run format && pnpm run lint && pnpm run typecheck && pnpm run test:types`
- [x] `pnpm run check:versions -- --npm && pnpm run release:source && pnpm run compare:published`
- [ ] `pnpm exec vitest run --config vitest.unit.config.ts test/nuxt-i18n.test.ts --typecheck.enabled=false`
- [ ] Optional: set `cacheMaxSize: 3` in playground, navigate many pages, confirm memory/chunks stay bounded and current page `$t` works


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Applies `i18n.cacheMaxSize` to the client `NuxtI18n.storage.translations` Map with FIFO-by-write-order eviction to bound SPA memory. Active and just-written keys are preferred; if both can’t fit (e.g. `1`), the just-written key wins. Default `0` stays unlimited; fetch/server caches are unchanged.

- New Features
  - Passes `cacheMaxSize` to `NuxtI18n` via the plugin; eviction runs on set, merge, seed, and during navigation.
  - Docs/news clarify FIFO by write order (reads don’t refresh recency) and when to set a limit; tests cover limits, `cacheMaxSize: 1`, and unlimited mode.

- Bug Fixes
  - Fixed Vue DevTools inspector state key formatting in `vue-devtools.ts`.

<sup>Written for commit 6e5888c9eadc7df793d51074a4576a81d2c59fdb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/s00d/nuxt-i18n-micro/pull/248?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

