### PR TITLE
docs: add AGENTS.md with Cursor Cloud dev environment setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,50 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This repo is the `nuxt-i18n-micro` pnpm monorepo (Node 22 / pnpm 9.14.2 are preinstalled). The
+startup update script already runs `pnpm install`. No Docker, database, or external service is
+required; integration/e2e tests spawn their own Nuxt servers in-process.
+
+### Build order matters (non-obvious gotcha)
+
+Before running tests, typecheck, or the dev server on a fresh checkout, run the build steps in this
+exact order (the dependency runs both ways):
+
+```bash
+pnpm --filter "./packages/**" --filter "!./packages/*/playground" run build
+pnpm run dev:prepare
+pnpm --filter "./packages/*/playground" run build
+```
+
+- `dev:prepare` loads `src/module.ts`, which imports the `@i18n-micro/*` packages from their
+  `dist/`, so packages must be built first. It also generates `.nuxt/tsconfig.json`, which the root
+  `tsconfig.json` extends.
+- The last step (building the package playgrounds) is easy to forget but **required for
+  `pnpm run test:unit` / `pnpm run typecheck` to pass**: the Astro playground build generates the
+  `virtual:i18n-micro/config` type declaration used by `packages/astro/playground/src/middleware.ts`.
+  Skip it and `test:unit` fails with `Cannot find module 'virtual:i18n-micro/config'` even though all
+  280 runtime tests still pass. This mirrors the order in `.github/workflows/ci.yml`.
+
+### Running the app (dev)
+
+`pnpm run dev` starts the main playground (Nuxt) on http://localhost:3000. The root path 302-redirects
+to the default locale (`/en`); locales are prefixed (`/en`, `/de`, `/fr`, `/es`). The startup
+warnings about `localeCookie` and large translation payloads are expected in the playground and are
+not errors.
+
+### Lint / test / build reference
+
+Standard commands live in `package.json` scripts and `.github/CONTRIBUTING.md`. Key ones:
+
+- Lint: `pnpm run lint` (oxlint), format: `pnpm run format` (oxfmt)
+- Unit tests: `pnpm run test:unit` (fast; includes tsc/vue-tsc typecheck of `test/**`)
+- Full suite: `pnpm run test` (unit + integration + e2e + package projects)
+- E2E needs a browser first: `pnpm exec playwright install chromium`
+- Typecheck: `pnpm run typecheck`
+
+### Package changes
+
+Per `.cursor/rules/package-versioning.mdc`: after editing anything under `packages/<name>/` (or `src/`
+for the root module), bump the affected `package.json` patch version once per PR and rebuild that
+package (`pnpm --filter @i18n-micro/<name> build`).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and documents the development environment for the `nuxt-i18n-micro` monorepo so future Cloud Agents can build, lint, test, and run the app reliably.

This PR only adds `AGENTS.md` (no source changes). The environment itself is refreshed by the startup update script (`pnpm install`).

## What was verified

- `pnpm install` — dependencies install cleanly (Node 22, pnpm 9.14.2)
- Build: `pnpm --filter "./packages/**" --filter "!./packages/*/playground" run build` + `pnpm run dev:prepare` + `pnpm --filter "./packages/*/playground" run build`
- Lint: `pnpm run lint` (oxlint) — passes
- Typecheck: `pnpm run typecheck` — passes
- Tests: `pnpm run test:unit` — 33 files / 280 tests pass, no type errors
- Run: `pnpm run dev` — playground serves on http://localhost:3000, locale routing + translations work (`/en`, `/de`, `/fr`, `/es`)

## Key documented gotcha

`test:unit` / `typecheck` require building the **package playgrounds** (the Astro playground generates the `virtual:i18n-micro/config` type declaration). Without that step `test:unit` fails with `Cannot find module 'virtual:i18n-micro/config'` even though all runtime tests pass. Build order is captured in `AGENTS.md`, mirroring `.github/workflows/ci.yml`.

## Demo

[nuxt_i18n_micro_locale_switching_demo.mp4](https://cursor.com/agents/bc-7c861d18-0087-4b9b-a655-298b8b8a2c3d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fnuxt_i18n_micro_locale_switching_demo.mp4)

[English home](https://cursor.com/agents/bc-7c861d18-0087-4b9b-a655-298b8b8a2c3d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdemo_en_home.webp)
[German home](https://cursor.com/agents/bc-7c861d18-0087-4b9b-a655-298b8b8a2c3d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdemo_de_home.webp)
[Spanish home](https://cursor.com/agents/bc-7c861d18-0087-4b9b-a655-298b8b8a2c3d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdemo_es_home.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7c861d18-0087-4b9b-a655-298b8b8a2c3d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7c861d18-0087-4b9b-a655-298b8b8a2c3d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `AGENTS.md` with Cursor Cloud dev environment setup for the `nuxt-i18n-micro` pnpm monorepo. Documents the exact build order and key commands so build, lint, typecheck, tests, and dev server work reliably, including the playground build step to prevent `Cannot find module 'virtual:i18n-micro/config'` errors.

<sup>Written for commit f7c5f2a14d7b8d9e21877a2d9d6a39bfed39e43d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/s00d/nuxt-i18n-micro/pull/250?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

