### PR TITLE
fix(runtime): locale detection skipped when a query value contains a dot

### DIFF
--- a/src/runtime/server/middleware/i18n.global.ts
+++ b/src/runtime/server/middleware/i18n.global.ts
@@ -17,7 +17,7 @@ import { loadTranslationsFromServer } from '../utils/server-loader'
 
 export default defineEventHandler(async (event) => {
   const appBaseURL = useRuntimeConfig(event).app.baseURL
-  const rawPath = event.path || getRequestURL(event).pathname
+  const rawPath = getRequestURL(event).pathname
   const path = withoutAppBaseURL(rawPath, appBaseURL)
 
   if (path.startsWith('/api') || path.startsWith('/_nuxt') || path.startsWith('/_locales') || path.startsWith('/__')) return

--- a/test/auto-detect-path.spec.ts
+++ b/test/auto-detect-path.spec.ts
@@ -12,6 +12,17 @@ describe('autoDetectPath: `/` (#242)', () => {
     await expect(page).toHaveURL('/de')
   })
 
+  test('cookie redirects `/` when a query value contains a dot', async ({ page, goto, baseURL }) => {
+    await page.context().clearCookies()
+    await page.context().addCookies([{ name: 'user-locale', value: 'de', url: baseURL! }])
+
+    // The dot in the query value must not be mistaken for a static-asset
+    // extension by the server middleware
+    await goto('/?utm_source=news.example.com', { waitUntil: 'hydration' })
+
+    await expect(page).toHaveURL('/de?utm_source=news.example.com')
+  })
+
   test('deep unprefixed links are not rewritten by the cookie', async ({ page, goto, baseURL }) => {
     await page.context().clearCookies()
     await page.context().addCookies([{ name: 'user-locale', value: 'de', url: baseURL! }])


### PR DESCRIPTION
## 📝 Description

The Nitro server middleware (`src/runtime/server/middleware/i18n.global.ts`) feeds `event.path` into its static-asset check:

```ts
const rawPath = event.path || getRequestURL(event).pathname
// ...
if (path.includes('.') && !path.endsWith('.html')) return
```

`event.path` includes the query string, so any dot inside a query **value** trips the check and the middleware returns early for a regular page. `event.context.i18n` is then never set, `resolveInitialLocale` seeds the SSR locale state from the route instead of the visitor's preference, and the redirect plugin — which consults the state before the cookie — silently skips the cookie redirect.

User-visible symptom (strategy `prefix_except_default`, `localeCookie` set, cookie `de`):

| request | result |
|---|---|
| `/?utm_source=example` | 302 → `/de?utm_source=example` ✅ |
| `/?utm_source=news.example.com` | 200, stays on `/` ❌ |

Any URL whose query contains a dot is affected — UTM parameters carrying domains, email addresses, callback/confirmation URLs passed as query params, version numbers (`?v=1.2`), etc.

The fix uses `getRequestURL(event).pathname`, which `06.redirect.ts` already uses for the same check.

## 🔗 Related Issue

None filed — this PR carries the report.

## 🎯 Type of Change

- [x] 🐛 Bug fix

## 🧪 Testing

### Environment

- **OS**: macOS
- **Node**: 24
- **Nuxt**: 3 (repo fixtures)

### Tested

- [x] Existing tests pass (`pnpm run test:unit` — 280 passed; e2e: `auto-detect-path`, `cookie-redirect`, `cookie`, `auto-detect-no-prefix`, `basic`, `baseurl-prefix-redirect` — all passed)
- [x] Added new tests (regression test in `test/auto-detect-path.spec.ts`; fails on `main`, passes with the fix)
- [x] Manual testing (curl against a `prefix_except_default` app with a locale cookie)

## 📋 Checklist

- [x] Code follows style guidelines
- [x] Self-reviewed my code
- [x] Commented complex code
- [ ] Updated documentation
- [x] Updated types (if needed)
- [x] No new warnings/errors
- [x] Tests pass

## 💡 Notes

The dot check itself (`path.includes('.')`) is untouched — only its input changes. I left the version bump out; happy to add one if you prefer contributors to include it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes locale detection being skipped when a query value contains a dot, which silently broke cookie redirects for URLs like `/?utm_source=news.example.com`.

**Bug Fixes**
- The server middleware now uses `getRequestURL(event).pathname` instead of `event.path` for its static-asset check, since `event.path` includes the query string.
- Previously, a dot in a query value (UTM sources, emails, callback URLs, version numbers) made the middleware return early; `event.context.i18n` was never set, the SSR locale state was seeded from the route instead of the visitor's preference, and the cookie redirect on unprefixed paths silently stopped working.
- Adds a regression test covering `/` with a dotted query value.

<sup>Written for commit 4028ab2e91d840b0965f3ff1fecaa8c34c90a52a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/s00d/nuxt-i18n-micro/pull/252?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

