### PR TITLE
fix(path-strategy): $localeRoute drops query params from string inputs

### DIFF
--- a/docs/api/packages/path-strategy.md
+++ b/docs/api/packages/path-strategy.md
@@ -28,7 +28,7 @@ import { /* … */ } from '@i18n-micro/path-strategy'
 | `isIndexRouteName` | function | `(name: string \| null \| undefined, options?: IsIndexRouteNameOptions) => boolean` |
 | `IsIndexRouteNameOptions` | interface | 2 members |
 | `NoPrefixPathStrategy` | class | 36 members |
-| `NormalizedRouteInput` | type | `\| { kind: 'path'; path: string } \| { kind: 'route'; inputName: string \| null; sourceRoute: RouteLike; resolved: ResolvedRouteLike }` |
+| `NormalizedRouteInput` | type | `\| { kind: 'path'; path: string; query?: Record<string, unknown>; hash?: string } \| { kind: 'route'; inputName: string \| null; sourceRoute: RouteLike; resolved: ResolvedRouteLike }` |
 | `PathStrategy` | interface | 22 members |
 | `PathStrategyContext` | interface | 15 members |
 | `PrefixAndDefaultPathStrategy` | class | 37 members |
@@ -448,7 +448,7 @@ import { /* … */ } from '@i18n-micro/path-strategy/types'
 | Export | Kind | Signature |
 | --- | --- | --- |
 | `GlobalLocaleRoutes` | type | `Record<string, Record<string, string> \| false \| boolean>` |
-| `NormalizedRouteInput` | type | `\| { kind: 'path'; path: string } \| { kind: 'route'; inputName: string \| null; sourceRoute: RouteLike; resolved: ResolvedRouteLike }` |
+| `NormalizedRouteInput` | type | `\| { kind: 'path'; path: string; query?: Record<string, unknown>; hash?: string } \| { kind: 'route'; inputName: string \| null; sourceRoute: RouteLike; resolved: ResolvedRouteLike }` |
 | `PathStrategy` | interface | 22 members |
 | `PathStrategyContext` | interface | 15 members |
 | `ResolvedRouteLike` | interface | 6 members |

--- a/docs/news/index.md
+++ b/docs/news/index.md
@@ -6,6 +6,16 @@ outline: 'deep'
 
 # News
 
+## localeRoute keeps query and hash from string inputs
+
+**Date**: 2026-08-27
+
+**Status**: unreleased (ships with the next `pnpm -C scripts cli release`)
+
+`$localeRoute('/products?sort=price')` now returns `query` (and `hash`) as separate fields instead of leaving them embedded in `path`, where vue-router ignores them — so `<NuxtLink :to="$localeRoute(...)">` no longer drops the params. API surface: the `path` variant of `NormalizedRouteInput` gains optional `query`/`hash` fields (additive; object inputs are unchanged).
+
+---
+
 ## Meta refresh on locale-only switches
 
 **Date**: 2026-08-27

--- a/packages/path-strategy/package.json
+++ b/packages/path-strategy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@i18n-micro/path-strategy",
-  "version": "1.3.11",
+  "version": "1.3.12",
   "description": "Shared strategy-based path and route name builder for Nuxt I18n Micro frontend routing.",
   "keywords": [
     "i18n",

--- a/packages/path-strategy/src/path.ts
+++ b/packages/path-strategy/src/path.ts
@@ -181,8 +181,10 @@ export function buildUrl(path: string, query?: Record<string, any>, hash?: strin
 
       if (value === undefined || value === null) continue
 
+      const encodedKey = UNSAFE_CHARS_RE.test(key) ? encodeURIComponent(key) : key
+
       if (Array.isArray(value)) {
-        const keyPrefix = `${key}=`
+        const keyPrefix = `${encodedKey}=`
         for (let i = 0, len = value.length; i < len; i++) {
           const val = value[i]
           if (val === undefined || val === null) continue
@@ -225,7 +227,7 @@ export function buildUrl(path: string, query?: Record<string, any>, hash?: strin
           separator = '&'
         }
 
-        url += `${separator + key}=${encodedVal}`
+        url += `${separator + encodedKey}=${encodedVal}`
       }
     }
   }
@@ -235,6 +237,26 @@ export function buildUrl(path: string, query?: Record<string, any>, hash?: strin
   }
 
   return url
+}
+
+/**
+ * Parse a query string into an object — the counterpart of buildUrl.
+ * URLSearchParams does the decoding; repeated keys collect into an array.
+ */
+export function parseQuery(search: string): Record<string, string | string[]> {
+  const query: Record<string, string | string[]> = Object.create(null)
+  if (!search || search === '?') return query
+  for (const [key, value] of new URLSearchParams(search)) {
+    const existing = query[key]
+    if (existing === undefined) {
+      query[key] = value
+    } else if (Array.isArray(existing)) {
+      existing.push(value)
+    } else {
+      query[key] = [existing, value]
+    }
+  }
+  return query
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/path-strategy/src/strategies/base-strategy.ts
+++ b/packages/path-strategy/src/strategies/base-strategy.ts
@@ -19,6 +19,8 @@ import {
   normalizePath,
   getLocaleFromPath as normalizerGetLocaleFromPath,
   getPathWithoutLocale as normalizerGetPathWithoutLocale,
+  parsePath,
+  parseQuery,
   withoutTrailingSlash,
 } from '../path'
 import {
@@ -173,7 +175,13 @@ export abstract class BasePathStrategy implements PathStrategy {
   localeRoute(targetLocale: string, routeOrPath: RouteLike | string, currentRoute?: ResolvedRouteLike): RouteLike {
     const normalized = this._normalizeRouteInput(routeOrPath, currentRoute)
     const raw = this.resolveLocaleRoute(targetLocale, normalized, currentRoute)
-    return this._ensureRouteLike(raw, normalized.kind === 'route' ? normalized.sourceRoute : undefined)
+    const source =
+      normalized.kind === 'route'
+        ? normalized.sourceRoute
+        : normalized.query || normalized.hash
+          ? { query: normalized.query, hash: normalized.hash }
+          : undefined
+    return this._ensureRouteLike(raw, source)
   }
 
   _ensureRouteLike(value: RouteLike | string, source?: RouteLike | null): RouteLike {
@@ -207,7 +215,16 @@ export abstract class BasePathStrategy implements PathStrategy {
   }
 
   _normalizeRouteInput(routeOrPath: RouteLike | string, _currentRoute?: ResolvedRouteLike): NormalizedRouteInput {
-    if (typeof routeOrPath === 'string') return { kind: 'path', path: routeOrPath }
+    if (typeof routeOrPath === 'string') {
+      // vue-router ignores a query string inside an object location's `path`,
+      // so split it off and carry query/hash as separate fields.
+      if (routeOrPath.indexOf('?') === -1 && routeOrPath.indexOf('#') === -1) return { kind: 'path', path: routeOrPath }
+      const { pathname, search, hash } = parsePath(routeOrPath)
+      const input: NormalizedRouteInput = { kind: 'path', path: pathname }
+      if (search && search !== '?') input.query = parseQuery(search)
+      if (hash && hash !== '#') input.hash = hash
+      return input
+    }
     const sourceRoute = routeOrPath
     const inputName = sourceRoute.name?.toString() ?? null
     let resolved: ResolvedRouteLike

--- a/packages/path-strategy/src/types.ts
+++ b/packages/path-strategy/src/types.ts
@@ -25,7 +25,7 @@ export interface ResolvedRouteLike extends RouteLike {
 
 /** Normalized input for resolveLocaleRoute (template method). */
 export type NormalizedRouteInput =
-  | { kind: 'path'; path: string }
+  | { kind: 'path'; path: string; query?: Record<string, unknown>; hash?: string }
   | { kind: 'route'; inputName: string | null; sourceRoute: RouteLike; resolved: ResolvedRouteLike }
 
 export interface RouterAdapter {

--- a/packages/path-strategy/tests/locale-route-string-query.test.ts
+++ b/packages/path-strategy/tests/locale-route-string-query.test.ts
@@ -1,0 +1,144 @@
+/**
+ * localeRoute with a string input like '/products?sort=price' must return the
+ * query and hash as separate fields, not embedded in `path`: vue-router
+ * ignores a query string inside an object location's `path`, so a NuxtLink
+ * fed such a result navigates without the params.
+ */
+import type { ModuleOptionsExtend } from '@i18n-micro/types'
+import type { PathStrategyContext } from '../src'
+import { createPathStrategy } from '../src'
+import { makePathStrategyContext, makeRouterAdapter } from './test-utils'
+import { describe, expect, test } from 'vitest'
+
+const baseConfig: ModuleOptionsExtend = {
+  defaultLocale: 'en',
+  strategy: 'prefix_except_default',
+  locales: [
+    { code: 'en', iso: 'en-US' },
+    { code: 'de', iso: 'de-DE' },
+  ],
+  dateBuild: 0,
+  hashMode: false,
+  isSSG: false,
+  apiBaseUrl: '',
+  disablePageLocales: false,
+}
+
+type StrategyName = 'prefix_except_default' | 'prefix' | 'prefix_and_default' | 'no_prefix'
+
+function makeStrategy(strategy: StrategyName, extra?: Partial<PathStrategyContext>) {
+  const router = makeRouterAdapter(['products', 'localized-products-en', 'localized-products-de'])
+  return createPathStrategy(makePathStrategyContext(baseConfig, strategy, { router, ...extra }))
+}
+
+const prefixed: Record<StrategyName, boolean> = {
+  prefix_except_default: false,
+  prefix: true,
+  prefix_and_default: true,
+  no_prefix: false,
+}
+
+function runStringQueryTests(strategy: StrategyName) {
+  const enPath = prefixed[strategy] ? '/en/products' : '/products'
+
+  test('string path with query: query must survive as a separate field', () => {
+    const s = makeStrategy(strategy)
+    const result = s.localeRoute('en', '/products?sort=price')
+    expect(result.path).toBe(enPath)
+    expect(result.query).toEqual({ sort: 'price' })
+    expect(result.fullPath).toBe(`${enPath}?sort=price`)
+  })
+
+  test('string path with query for a prefixed locale', () => {
+    const s = makeStrategy(strategy)
+    const result = s.localeRoute('de', '/products?sort=price')
+    const dePath = strategy === 'no_prefix' ? '/products' : '/de/products'
+    expect(result.path).toBe(dePath)
+    expect(result.query).toEqual({ sort: 'price' })
+    expect(result.fullPath).toBe(`${dePath}?sort=price`)
+  })
+
+  test('string path with multiple query params and hash', () => {
+    const s = makeStrategy(strategy)
+    const result = s.localeRoute('en', '/products?a=1&b=2#frag')
+    expect(result.path).toBe(enPath)
+    expect(result.query).toEqual({ a: '1', b: '2' })
+    expect(result.hash).toBe('#frag')
+    expect(result.fullPath).toBe(`${enPath}?a=1&b=2#frag`)
+  })
+
+  test('string path with hash only', () => {
+    const s = makeStrategy(strategy)
+    const result = s.localeRoute('en', '/products#frag')
+    expect(result.path).toBe(enPath)
+    expect(result.hash).toBe('#frag')
+    expect(result.fullPath).toBe(`${enPath}#frag`)
+  })
+
+  test('string path with an empty query or hash drops them from both fields', () => {
+    const s = makeStrategy(strategy)
+    const withEmptyHash = s.localeRoute('en', '/products#')
+    expect(withEmptyHash.hash).toBeUndefined()
+    expect(withEmptyHash.fullPath).toBe(enPath)
+    const withEmptyQuery = s.localeRoute('en', '/products?')
+    expect(withEmptyQuery.query).toBeUndefined()
+    expect(withEmptyQuery.fullPath).toBe(enPath)
+  })
+
+  test('string path with repeated query key parses to an array', () => {
+    const s = makeStrategy(strategy)
+    const result = s.localeRoute('en', '/products?tag=a&tag=b')
+    expect(result.query).toEqual({ tag: ['a', 'b'] })
+    expect(result.fullPath).toBe(`${enPath}?tag=a&tag=b`)
+  })
+
+  test('string path without query/hash is unaffected', () => {
+    const s = makeStrategy(strategy)
+    const result = s.localeRoute('en', '/products')
+    expect(result.path).toBe(enPath)
+    expect(result.query).toBeUndefined()
+    expect(result.fullPath).toBe(enPath)
+  })
+}
+
+describe('localeRoute: string input with embedded query/hash', () => {
+  describe('prefix_except_default', () => {
+    runStringQueryTests('prefix_except_default')
+  })
+
+  describe('prefix', () => {
+    runStringQueryTests('prefix')
+  })
+
+  describe('prefix_and_default', () => {
+    runStringQueryTests('prefix_and_default')
+  })
+
+  describe('no_prefix', () => {
+    runStringQueryTests('no_prefix')
+  })
+
+  test('custom path lookup is not defeated by an embedded query', () => {
+    const s = makeStrategy('prefix_except_default', {
+      globalLocaleRoutes: { products: { en: '/catalog', de: '/katalog' } },
+      _hasGR: true,
+    })
+    const result = s.localeRoute('de', '/products?sort=price')
+    expect(result.path).toBe('/de/katalog')
+    expect(result.query).toEqual({ sort: 'price' })
+    expect(result.fullPath).toBe('/de/katalog?sort=price')
+  })
+
+  test('encoded query values are decoded like vue-router does', () => {
+    const s = makeStrategy('prefix_except_default')
+    const result = s.localeRoute('en', '/products?redirect=%2Fdashboard%3Ftab%3D1')
+    expect(result.query).toEqual({ redirect: '/dashboard?tab=1' })
+  })
+
+  test('flag param without a value survives in query and fullPath', () => {
+    const s = makeStrategy('prefix_except_default')
+    const result = s.localeRoute('en', '/products?flag')
+    expect(result.query).toEqual({ flag: '' })
+    expect(result.fullPath).toBe('/products?flag=')
+  })
+})

--- a/packages/path-strategy/tests/path-utils.test.ts
+++ b/packages/path-strategy/tests/path-utils.test.ts
@@ -2,6 +2,7 @@
  * Unit tests for path utils: parentKeyFromSlashKey, lastPathSegment, nameKeyFirstSlash, nameKeyLastSlash.
  */
 import {
+  buildUrl,
   getParentPath,
   joinUrl,
   lastPathSegment,
@@ -9,6 +10,7 @@ import {
   nameKeyLastSlash,
   normalizePath,
   parentKeyFromSlashKey,
+  parseQuery,
   transformNameKeyToPath,
 } from '../src/path'
 import { describe, expect, test } from 'vitest'
@@ -119,5 +121,53 @@ describe('transformNameKeyToPath', () => {
 
   test('a-b-c-d -> a/b/c/d', () => {
     expect(transformNameKeyToPath('a-b-c-d')).toBe('a/b/c/d')
+  })
+})
+
+describe('parseQuery / buildUrl round-trip', () => {
+  test('basic pairs', () => {
+    expect(parseQuery('a=1&b=2')).toEqual({ a: '1', b: '2' })
+    expect(buildUrl('/p', parseQuery('a=1&b=2'))).toBe('/p?a=1&b=2')
+  })
+
+  test('leading ? is tolerated', () => {
+    expect(parseQuery('?a=1')).toEqual({ a: '1' })
+  })
+
+  test('repeated keys collect into an array and round-trip', () => {
+    expect(parseQuery('tag=a&tag=b')).toEqual({ tag: ['a', 'b'] })
+    expect(buildUrl('/p', parseQuery('tag=a&tag=b'))).toBe('/p?tag=a&tag=b')
+  })
+
+  test('a key without = maps to an empty string', () => {
+    expect(parseQuery('flag')).toEqual({ flag: '' })
+    expect(buildUrl('/p', parseQuery('flag'))).toBe('/p?flag=')
+    expect(buildUrl('/p', parseQuery('flag&a=1'))).toBe('/p?flag=&a=1')
+    expect(parseQuery('flag&flag=x')).toEqual({ flag: ['', 'x'] })
+  })
+
+  test('+ means space, encoded values are decoded', () => {
+    expect(parseQuery('q=hello+world')).toEqual({ q: 'hello world' })
+    expect(parseQuery('redirect=%2Fdash%3Ftab%3D1')).toEqual({ redirect: '/dash?tab=1' })
+  })
+
+  // parseQuery stores keys on a null-prototype object. On a plain object,
+  // a key like 'toString' reads the inherited function as a prior value,
+  // and '__proto__' does not create an own property.
+  test('prototype names land as own properties', () => {
+    expect(parseQuery('toString=x')).toEqual({ toString: 'x' })
+    expect(parseQuery('constructor=y')).toEqual({ constructor: 'y' })
+    // A literal { __proto__: 'z' } would set the prototype, so assert by access.
+    expect(parseQuery('__proto__=z')['__proto__']).toBe('z')
+  })
+
+  test('encoded delimiters in keys stay unambiguous through buildUrl', () => {
+    expect(parseQuery('a%3Db=1')).toEqual({ 'a=b': '1' })
+    expect(buildUrl('/p', parseQuery('a%3Db=1'))).toBe('/p?a%3Db=1')
+  })
+
+  test('empty and ?-only inputs give an empty object', () => {
+    expect(parseQuery('')).toEqual({})
+    expect(parseQuery('?')).toEqual({})
   })
 })

--- a/scripts/api-surface/i18n-micro__path-strategy.api.txt
+++ b/scripts/api-surface/i18n-micro__path-strategy.api.txt
@@ -85,7 +85,7 @@ member NoPrefixPathStrategy.setRouter: (router: RouterAdapter) => void
 member NoPrefixPathStrategy.shouldReturn404: (_currentPath: string) => string | null
 member NoPrefixPathStrategy.switchLocaleRoute: (fromLocale: string, toLocale: string, route: ResolvedRouteLike, options: SwitchLocaleOptions) => RouteLike | string
 member NoPrefixPathStrategy.new: (ctx: PathStrategyContext): NoPrefixPathStrategy
-type NormalizedRouteInput: | { kind: 'path'; path: string } | { kind: 'route'; inputName: string | null; sourceRoute: RouteLike; resolved: ResolvedRouteLike }
+type NormalizedRouteInput: | { kind: 'path'; path: string; query?: Record<string, unknown>; hash?: string } | { kind: 'route'; inputName: string | null; sourceRoute: RouteLike; resolved: ResolvedRouteLike }
 interface PathStrategy
 member PathStrategy.formatPathForResolve: (path: string, fromLocale: string, toLocale: string) => string
 member PathStrategy.getCanonicalPath: (route: ResolvedRouteLike, targetLocale: string) => string | null
@@ -594,7 +594,7 @@ member Strategy.new: (ctx: PathStrategyContext): PrefixExceptDefaultPathStrategy
 
 # ./types (src/types.ts)
 type GlobalLocaleRoutes: Record<string, Record<string, string> | false | boolean>
-type NormalizedRouteInput: | { kind: 'path'; path: string } | { kind: 'route'; inputName: string | null; sourceRoute: RouteLike; resolved: ResolvedRouteLike }
+type NormalizedRouteInput: | { kind: 'path'; path: string; query?: Record<string, unknown>; hash?: string } | { kind: 'route'; inputName: string | null; sourceRoute: RouteLike; resolved: ResolvedRouteLike }
 interface PathStrategy
 member PathStrategy.formatPathForResolve: (path: string, fromLocale: string, toLocale: string) => string
 member PathStrategy.getCanonicalPath: (route: ResolvedRouteLike, targetLocale: string) => string | null

--- a/test/basic.spec.ts
+++ b/test/basic.spec.ts
@@ -535,6 +535,10 @@ describe('basic', () => {
     // Check that localeRoute works correctly with query and hash
     await page.click('.link-news-2')
     await expect(page).toHaveURL('/news/2?a=b')
+
+    // Check that a string path with an embedded query keeps the query
+    await page.click('.link-news-3-string')
+    await expect(page).toHaveURL('/news/3?sort=date')
   })
 
   test('test navigation and locale switching on articles page', async ({ page, goto }) => {

--- a/test/fixtures/basic/pages/news/[id].vue
+++ b/test/fixtures/basic/pages/news/[id].vue
@@ -17,6 +17,7 @@
       "
       >news-2</NuxtLink
     >
+    <NuxtLink class="link-news-3-string" :to="$localeRoute('/news/3?sort=date')"> news-3-string </NuxtLink>
 
     <div class="news-link-path">
       <pre>{{ newsLink.fullPath }}</pre>


### PR DESCRIPTION
## 📝 Description

`$localeRoute()` (and therefore `$localePath()` / `<NuxtLink :to="$localeRoute(...)">`) silently drops query params and hashes when the input is a **string** with them embedded:

```ts
$localeRoute('/products?sort=price', 'de')
// ACTUAL:   { path: '/de/products?sort=price', fullPath: '/de/products?sort=price' }
// EXPECTED: { path: '/de/products', query: { sort: 'price' }, fullPath: '/de/products?sort=price' }
```

The query stays glued inside `path` and no `query` field is populated. vue-router documents that a query string embedded in an object location's `path` is **ignored**: resolving `{ path: '/products?sort=price' }` yields href `/products` with `query: {}` (resolving the same value as a plain string keeps it). So a `NuxtLink` fed that object navigates to `/products` and the params vanish — no warning anywhere.

Where it happens, in `@i18n-micro/path-strategy`:

- `BaseStrategy._normalizeRouteInput` returns string inputs as `{ kind: 'path', path }` without splitting off `?`/`#`, so the strategies prefix the locale onto the raw string (this also defeats `globalLocaleRoutes` custom-path lookups, which are keyed by the clean path).
- `_ensureRouteLike` then keeps the whole string as `path`. It already knows how to attach `query`/`hash` from a source route — that branch just never fires for string inputs, because `localeRoute` only passes a source for object inputs.

The fix follows the seams that are already there: `_normalizeRouteInput` splits the string with the existing `parsePath` helper and parses the query with a new `parseQuery` — a thin wrapper over native `URLSearchParams` (already used elsewhere in the monorepo) that collects repeated keys into arrays, the missing counterpart of the `buildUrl` stringifier `_ensureRouteLike` already uses. `localeRoute` then hands the parsed query/hash to `_ensureRouteLike` the same way it does for object inputs, and the strategies see the bare path. `buildUrl` also now encodes unsafe query keys with the same rule it already applies to values, so a decoded key round-trips unambiguously.

Object inputs (`{ name, params, query }`) were never affected — `preserveQueryAndHash` covers those, and `tests/locale-route-query-hash.test.ts` already locks them down. This is the string-input twin of that case.

## 🔗 Related Issue

None filed — this PR carries the report. (#58 was the same symptom for `$localePath`, fixed in v1.31.2; v2.7.0 still handled it by running string inputs through `router.resolve(string)`, and the behavior regressed with the v3 path-strategy extraction.)

## 🎯 Type of Change

- [x] 🐛 Bug fix

## 🧪 Testing

### Environment

- **OS**: macOS
- **Node**: 24
- **Nuxt**: 3 (repo fixtures)

### Tested

- [x] Existing tests pass (`packages/path-strategy`: 395 passed; root `pnpm run test:unit`: 280 passed; e2e `basic.spec.ts` passed; `lint` and package `typecheck` clean)
- [x] Added new tests (`packages/path-strategy/tests/locale-route-string-query.test.ts` — all but the no-query control cases fail on `main`, all pass with the fix; `parseQuery`/`buildUrl` round-trip cases in `path-utils.test.ts`; plus an e2e click-through in `basic.spec.ts` asserting the query survives navigation)
- [x] Manual testing (found in production after upgrading 2.7.0 → 3.28.x: links built from string paths lost their query params)

## 📋 Checklist

- [x] Code follows style guidelines
- [x] Self-reviewed my code
- [x] Commented complex code
- [x] Updated documentation (API snapshot, generated `docs/api` page, and a `docs/news` entry for the `NormalizedRouteInput` addition)
- [x] Updated types (if needed — `NormalizedRouteInput`'s `path` kind now carries optional `query`/`hash`)
- [x] No new warnings/errors
- [x] Tests pass

## 💡 Notes

Prior art: `@nuxtjs/i18n` fixed the identical bug class in nuxt-modules/i18n#1103.

`parseQuery` lives next to `buildUrl` in `path.ts` and keeps the file's no-runtime-regex rule. Bumped `@i18n-micro/path-strategy` to 1.3.12 (`check:versions` enforces it).
