### PR TITLE
Fix/generated types not inferred

### DIFF
--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -17,7 +17,7 @@ export interface DefineLocaleMessage {
  * - When `DefineLocaleMessage` has keys — resolves to a union of those keys **and** `string`,
  *   providing autocompletion while still allowing dynamic keys.
  */
-export type TranslationKey = keyof DefineLocaleMessage extends never ? string : keyof DefineLocaleMessage | string
+export type TranslationKey = keyof DefineLocaleMessage extends never ? string : keyof DefineLocaleMessage | (string & {})
 
 /**
  * Helper for creating typed prefixes.

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -17,7 +17,8 @@ export interface DefineLocaleMessage {
  * - When `DefineLocaleMessage` has keys — resolves to a union of those keys **and** `string`,
  *   providing autocompletion while still allowing dynamic keys.
  */
-export type TranslationKey = keyof DefineLocaleMessage extends never ? string : keyof DefineLocaleMessage | (string & {})
+export type TranslationKey =
+  Exclude<keyof DefineLocaleMessage, '__augmentation'> extends never ? string : Exclude<keyof DefineLocaleMessage, '__augmentation'> | (string & {})
 
 /**
  * Helper for creating typed prefixes.

--- a/src/runtime/plugins/01.plugin.ts
+++ b/src/runtime/plugins/01.plugin.ts
@@ -234,7 +234,7 @@ export interface PluginsInjections {
    * Like `$t`, but always returns a string: an object or array value is stringified rather than
    * returned as-is.
    */
-  $ts: TranslationFn<CleanTranslation>
+  $ts: TranslationFn<string>
   /** Bind `$ts` to a specific route. See `$_t`. */
   $_ts: (route: RouteLocationNormalizedLoaded) => TranslationFn<string>
   /**

--- a/src/runtime/plugins/01.plugin.ts
+++ b/src/runtime/plugins/01.plugin.ts
@@ -9,6 +9,7 @@ import type {
   ModuleOptionsExtend,
   Params,
   Translations,
+  TranslationKey,
 } from '@i18n-micro/types'
 import { resolveI18nConfigWithRuntimeOverrides } from '@i18n-micro/utils/runtime-config'
 import type {
@@ -202,6 +203,8 @@ export default defineNuxtPlugin(async (nuxtApp) => {
   }
 })
 
+export type TranslationFn<T extends CleanTranslation> = (key: TranslationKey, params?: Params, defaultValue?: string | null) => T
+
 export interface PluginsInjections {
   /** The active routing strategy, resolving locales to and from paths. */
   $i18nStrategy: PathStrategy
@@ -221,24 +224,24 @@ export interface PluginsInjections {
    * Translate a key, interpolating `params` into it. Returns `defaultValue` when the key is
    * missing, or the key itself when no default is given.
    */
-  $t: (key: string, params?: Params, defaultValue?: string | null) => CleanTranslation
+  $t: TranslationFn<CleanTranslation>
   /**
    * Bind `$t` to a specific route, for translating outside the current page — a layout rendering
    * a link to another route, for example.
    */
-  $_t: (route: RouteLocationNormalizedLoaded) => (key: string, params?: Params, defaultValue?: string | null) => CleanTranslation
+  $_t: (route: RouteLocationNormalizedLoaded) => TranslationFn<CleanTranslation>
   /**
    * Like `$t`, but always returns a string: an object or array value is stringified rather than
    * returned as-is.
    */
-  $ts: (key: string, params?: Params, defaultValue?: string) => string
+  $ts: TranslationFn<CleanTranslation>
   /** Bind `$ts` to a specific route. See `$_t`. */
-  $_ts: (route: RouteLocationNormalizedLoaded) => (key: string, params?: Params, defaultValue?: string | null) => string
+  $_ts: (route: RouteLocationNormalizedLoaded) => TranslationFn<string>
   /**
    * Translate with pluralization. `params` may be the count itself, or an object containing
    * `count`.
    */
-  $tc: (key: string, params: number | Params, defaultValue?: string) => string
+  $tc: (key: TranslationKey, params: number | Params, defaultValue?: string) => string
   /**
    * Format a number with `Intl.NumberFormat` in the active locale. A key selects a named format
    * from the config.


### PR DESCRIPTION
## 📝 Description

Fixes an issue where generated translation key types were not properly inferred or autocompleted by TypeScript in Nuxt plugin injections.

### Key Changes:
- **Prevent union type widening**: Updated `TranslationKey` in `packages/types/src/index.ts` from `keyof DefineLocaleMessage | string` to `keyof DefineLocaleMessage | (string & {})`. This prevents TypeScript from collapsing the union into `string`, preserving IDE autocompletion for generated keys while continuing to accept arbitrary strings.
- **Use `TranslationKey` / `TranslationFn` in plugin injections**: Updated `src/runtime/plugins/01.plugin.ts` to define `TranslationFn` and type `$t`, `$_t`, `$_ts`, and `$tc` with `TranslationKey` instead of plain `string`.

## 🔗 Related Issue

This PR carries the report.

## 🎯 Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance
- [ ] ✅ Tests

## 🧪 Testing

### Environment

- **OS**: Linux/Ubuntu-26.04
- **Node**: 24.20.0
- **Nuxt**: 4.x

### Tested

- [x] Existing tests pass (`pnpm test`)
- [ ] Added new tests
- [x] Manual testing
- [ ] Tested in production build

## 📋 Checklist

- [x] Code follows style guidelines
- [x] Self-reviewed my code
- [ ] Commented complex code
- [ ] Updated documentation
- [x] Updated types (if needed)
- [x] No new warnings/errors
- [x] Tests pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes translation key type inference in Nuxt plugin injections so IDE autocompletion works again for generated keys.

- `TranslationKey` now excludes the `'__augmentation'` key while preserving arbitrary strings via `(string & {})`.
- Types `$t`, `$_t`, `$ts`, `$_ts`, and `$tc` with `TranslationKey` instead of plain `string`.
- `$ts` and `$_ts` consistently return `string` via `TranslationFn<string>`.

<sup>Written for commit f062a5879b130f939957e366d82459d4bc18900c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/s00d/nuxt-i18n-micro/pull/256?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

